### PR TITLE
Package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "main": "SAT.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nickyout/sat-js.git"
+    "url": "https://github.com/jriecken/sat-js.git"
   }
 }


### PR DESCRIPTION
Upon converting my project from requirejs to browserify, I noticed that your repo could not be used as a node module the standard way (npm install), because it was lacking a package.json file and thus an entry point. 

Therefore, I created a package.json file. Afterwards, I could add my fork as a package.json dependency, run npm install succesfully and use your library simply by calling require("sat-js"). 

Assuming you see the benefit of this, I would like to offer you the file as pull request. 

The specified version number in officially needs to be semver-compliant ([major].[minor].[patch] which you do not always seem to comply). However, it is possible to specify a commit as dependency in npm, so I suppose that, as long as the package.json file simply exists with a valid version, you can use whatever version system you want. 

I would be much obliged. 
