### PR TITLE
Ensure allocations do not happen during Polygon.recalc. Fixes #15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## In development
 
- - Add `getAABB` to `Polygon` and `Circle` that calculate Axis-Aligned Bounding Boxes - thanks @TuurDutoit! (Fixes #17)
+ - **(POTENTIALLY BREAKING CHANGE)** Make `recalc` on `Polygon` more memory efficient. It no longer does any allocations. The `calcPoints`,`edges` and `normals` vector arrays are reused and only created in `setPoints` when the number of new points is different than the current ones. (Fixes #15)
+   - `points`, `angle` and `offset` can no longer be manually changed. The `setPoints`, `setAngle`, and `setOffset` methods **must** be used.
+   - As a result of this, the `recalc` method is no longer part of the API.
+ - Add `getAABB` to `Polygon` and `Circle` that calculate Axis-Aligned Bounding Boxes - thanks [TuurDutoit](https://github.com/TuurDutoit)! (Fixes #17)
 
 ## 0.4.1 (Mar 23, 2014)
 
- - Fix missing `T_VECTORS.push()` - thanks @shakiba! (Fixes #8)
+ - Fix missing `T_VECTORS.push()` - thanks [shakiba](https://github.com/shakiba)! (Fixes #8)
  - Add `package.json` - released as `npm` module (Fixes #11, Fixes #12)
 
 ## 0.4 (Mar 2, 2014)

--- a/README.md
+++ b/README.md
@@ -94,16 +94,17 @@ It has the following properties:
  - `points` - Array of vectors representing the original points of the polygon.
  - `angle` - Angle to rotate the polgon (affects `calcPoints`)
  - `offset` - Translation to apply to the polygon before the `angle` rotation (affects `calcPoints`)
- - `calcPoints` - The "calculated" collision polygon - effectively `points` with `angle` and `offset` applied.
- - `edges` - Array of Vectors representing the edges of the calculated polygon
- - `normals` - Array of Vectors representing the edge normals of the calculated polygon (perpendiculars)
+ - `calcPoints` - (Calculated) The collision polygon - effectively `points` with `angle` and `offset` applied.
+ - `edges` - (Calculated) Array of Vectors representing the edges of the calculated polygon
+ - `normals` - (Calculated) Array of Vectors representing the edge normals of the calculated polygon (perpendiculars)
+
+You should _not_ manually change any of the properties except `pos` - use the `setPoints`, `setAngle`, and `setOffset` methods to ensure that the calculated properties are updated correctly.
 
 It has the following methods:
 
- - `setPoints(points)` - Set the original points (calls `recalc` for you)
- - `setAngle(angle)` - Set the rotation angle (calls `recalc` for you)
- - `setOffset(offset)` - Set the offset (calls `recalc` for you)
- - `recalc()` - Call this method if you manually change `points`, `angle`, or `offset`.
+ - `setPoints(points)` - Set the original points
+ - `setAngle(angle)` - Set the current rotation angle (in radians)
+ - `setOffset(offset)` - Set the current offset
  - `rotate(angle)` - Rotate the original points of this polygon counter-clockwise (around its local coordinate system) by the specified number of radians. The `angle` rotation will be applied on top of this rotation.
  - `translate(x, y)` - Translate the original points of this polygin (relative to the local coordinate system) by the specified amounts. The `offset` translation will be applied on top of this translation.
  

--- a/SAT.js
+++ b/SAT.js
@@ -270,14 +270,16 @@
     var r = this['r'];
     var corner = this["pos"].clone().sub(new Vector(r, r));
     return new Box(corner, r*2, r*2).toPolygon();
-  }
+  };
 
   // ## Polygon
   //
   // Represents a *convex* polygon with any number of points (specified in counter-clockwise order)
   //
-  // Note: If you manually change the `points`, `angle`, or `offset` properties, you **must** call `recalc`
-  // afterwards so that the changes get applied correctly.
+  // Note: Do _not_ manually change the `points`, `angle`, or `offset` properties. Use the
+  // provided setters. Otherwise the calculated properties will not be updated correctly.
+  //
+  // `pos` can be changed directly.
 
   // Create a new polygon, passing in a position vector, and an array of points (represented
   // by vectors relative to the position vector). If no position is passed in, the position
@@ -291,57 +293,63 @@
    */
   function Polygon(pos, points) {
     this['pos'] = pos || new Vector();
-    this['points'] = points || [];
     this['angle'] = 0;
     this['offset'] = new Vector();
-    this.recalc();
+    this.setPoints(points || []);
   }
   SAT['Polygon'] = Polygon;
   
   // Set the points of the polygon.
-  //
-  // Note: This calls `recalc` for you.
   /**
    * @param {Array.<Vector>=} points An array of vectors representing the points in the polygon,
    *   in counter-clockwise order.
    * @return {Polygon} This for chaining.
    */
   Polygon.prototype['setPoints'] = Polygon.prototype.setPoints = function(points) {
+    // Only re-allocate if this is a new polygon or the number of points has changed.
+    var lengthChanged = !this['points'] || this['points'].length !== points.length;
+    if (lengthChanged) {
+      var i;
+      var calcPoints = this['calcPoints'] = [];
+      var edges = this['edges'] = [];
+      var normals = this['normals'] = [];
+      // Allocate the vector arrays for the calculated properties
+      for (i = 0; i < points.length; i++) {
+        calcPoints.push(new Vector());
+        edges.push(new Vector());
+        normals.push(new Vector());
+      }
+    }
     this['points'] = points;
-    this.recalc();
+    this._recalc();
     return this;
   };
 
   // Set the current rotation angle of the polygon.
-  //
-  // Note: This calls `recalc` for you.
   /**
    * @param {number} angle The current rotation angle (in radians).
    * @return {Polygon} This for chaining.
    */
   Polygon.prototype['setAngle'] = Polygon.prototype.setAngle = function(angle) {
     this['angle'] = angle;
-    this.recalc();
+    this._recalc();
     return this;
   };
 
   // Set the current offset to apply to the `points` before applying the `angle` rotation.
-  //
-  // Note: This calls `recalc` for you.
   /**
    * @param {Vector} offset The new offset vector.
    * @return {Polygon} This for chaining.
    */
   Polygon.prototype['setOffset'] = Polygon.prototype.setOffset = function(offset) {
     this['offset'] = offset;
-    this.recalc();
+    this._recalc();
     return this;
   };
 
   // Rotates this polygon counter-clockwise around the origin of *its local coordinate system* (i.e. `pos`).
   //
-  // Note: This changes the **original** points (so any `angle` will be applied on top of this rotation)
-  // Note: This calls `recalc` for you.
+  // Note: This changes the **original** points (so any `angle` will be applied on top of this rotation).
   /**
    * @param {number} angle The angle to rotate (in radians)
    * @return {Polygon} This for chaining.
@@ -352,7 +360,7 @@
     for (var i = 0; i < len; i++) {
       points[i].rotate(angle);
     }
-    this.recalc();
+    this._recalc();
     return this;
   };
 
@@ -363,7 +371,6 @@
   // the coordinates of `pos`.
   //
   // Note: This changes the **original** points (so any `offset` will be applied on top of this translation)
-  // Note: This calls `recalc` for you.
   /**
    * @param {number} x The horizontal amount to translate.
    * @param {number} y The vertical amount to translate.
@@ -376,39 +383,36 @@
       points[i].x += x;
       points[i].y += y;
     }
-    this.recalc();
+    this._recalc();
     return this;
   };
 
 
   // Computes the calculated collision polygon. Applies the `angle` and `offset` to the original points then recalculates the
   // edges and normals of the collision polygon.
-  //
-  // This **must** be called if the `points` array, `angle`, or `offset` is modified manualy.
   /**
    * @return {Polygon} This for chaining.
    */
-  Polygon.prototype['recalc'] = Polygon.prototype.recalc = function() {
-    var i;
+  Polygon.prototype._recalc = function() {
     // Calculated points - this is what is used for underlying collisions and takes into account
     // the angle/offset set on the polygon.
-    var calcPoints = this['calcPoints'] = [];
+    var calcPoints = this['calcPoints'];
     // The edges here are the direction of the `n`th edge of the polygon, relative to
     // the `n`th point. If you want to draw a given edge from the edge value, you must
     // first translate to the position of the starting point.
-    var edges = this['edges'] = [];
+    var edges = this['edges'];
     // The normals here are the direction of the normal for the `n`th edge of the polygon, relative
     // to the position of the `n`th point. If you want to draw an edge normal, you must first
     // translate to the position of the starting point.
-    var normals = this['normals'] = [];
+    var normals = this['normals'];
     // Copy the original points array and apply the offset/angle
     var points = this['points'];
     var offset = this['offset'];
     var angle = this['angle'];
     var len = points.length;
+    var i;
     for (i = 0; i < len; i++) {
-      var calcPoint = points[i].clone();
-      calcPoints.push(calcPoint);
+      var calcPoint = calcPoints[i].copy(points[i]);
       calcPoint.x += offset.x;
       calcPoint.y += offset.y;
       if (angle !== 0) {
@@ -419,10 +423,8 @@
     for (i = 0; i < len; i++) {
       var p1 = calcPoints[i];
       var p2 = i < len - 1 ? calcPoints[i + 1] : calcPoints[0];
-      var e = new Vector().copy(p2).sub(p1);
-      var n = new Vector().copy(e).perp().normalize();
-      edges.push(e);
-      normals.push(n);
+      var e = edges[i].copy(p2).sub(p1);
+      normals[i].copy(e).perp().normalize();
     }
     return this;
   };
@@ -458,7 +460,7 @@
       }
     }
     return new Box(this["pos"].clone().add(new Vector(xMin, yMin)), xMax - xMin, yMax - yMin).toPolygon();
-  }
+  };
   
 
   // ## Box


### PR DESCRIPTION
- This change also makes 'recalc' not be part of Polygon's API anymore
- The points, angle, and offset properties must not be manually changed - the setters must be used to ensure that the computed properties are updated
- New calcPoints, edges, and normals vector arrays are only allocation on a) construction of the polygon and b) if setPoints is called with an array that is a different length than the current points array
