### PR TITLE
Collision Tests header link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ SAT.js
 ======
 
  - [Classes](#classes)
- - [Collision Tests](#tests)
+ - [Collision Tests](#collision-tests)
  - [Examples](#examples)
 
 About


### PR DESCRIPTION
Current **Collision Tests** link leads to **Tests** section.