### PR TITLE
Updated to ES6 and bundled with Rollup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "@babel/env"
+  ]
+}

--- a/SAT.js
+++ b/SAT.js
@@ -1,1036 +1,1205 @@
-// Version 0.8.0 - Copyright 2012 - 2018 -  Jim Riecken <jimr@jimr.ca>
-//
-// Released under the MIT License - https://github.com/jriecken/sat-js
-//
-// A simple library for determining intersections of circles and
-// polygons using the Separating Axis Theorem.
-/** @preserve SAT.js - Version 0.8.0 - Copyright 2012 - 2018 - Jim Riecken <jimr@jimr.ca> - released under the MIT License. https://github.com/jriecken/sat-js */
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (global = global || self, global.SAT = factory());
+}(this, (function () { 'use strict';
 
-/*global define: false, module: false*/
-/*jshint shadow:true, sub:true, forin:true, noarg:true, noempty:true,
-  eqeqeq:true, bitwise:true, strict:true, undef:true,
-  curly:true, browser:true */
-
-// Create a UMD wrapper for SAT. Works in:
-//
-//  - Plain browser via global SAT variable
-//  - AMD loader (like require.js)
-//  - Node.js
-//
-// The quoted properties all over the place are used so that the Closure Compiler
-// does not mangle the exposed API in advanced mode.
-/**
- * @param {*} root - The global scope
- * @param {Function} factory - Factory that creates SAT module
- */
-(function (root, factory) {
-  "use strict";
-  if (typeof define === 'function' && define['amd']) {
-    define(factory);
-  } else if (typeof exports === 'object') {
-    module['exports'] = factory();
-  } else {
-    root['SAT'] = factory();
-  }
-}(this, function () {
-  "use strict";
-
-  var SAT = {};
-
-  //
-  // ## Vector
-  //
-  // Represents a vector in two dimensions with `x` and `y` properties.
-
-
-  // Create a new Vector, optionally passing in the `x` and `y` coordinates. If
-  // a coordinate is not specified, it will be set to `0`
-  /**
-   * @param {?number=} x The x position.
-   * @param {?number=} y The y position.
-   * @constructor
-   */
-  function Vector(x, y) {
-    this['x'] = x || 0;
-    this['y'] = y || 0;
-  }
-  SAT['Vector'] = Vector;
-  // Alias `Vector` as `V`
-  SAT['V'] = Vector;
-
-
-  // Copy the values of another Vector into this one.
-  /**
-   * @param {Vector} other The other Vector.
-   * @return {Vector} This for chaining.
-   */
-  Vector.prototype['copy'] = Vector.prototype.copy = function(other) {
-    this['x'] = other['x'];
-    this['y'] = other['y'];
-    return this;
-  };
-
-  // Create a new vector with the same coordinates as this on.
-  /**
-   * @return {Vector} The new cloned vector
-   */
-  Vector.prototype['clone'] = Vector.prototype.clone = function() {
-    return new Vector(this['x'], this['y']);
-  };
-
-  // Change this vector to be perpendicular to what it was before. (Effectively
-  // roatates it 90 degrees in a clockwise direction)
-  /**
-   * @return {Vector} This for chaining.
-   */
-  Vector.prototype['perp'] = Vector.prototype.perp = function() {
-    var x = this['x'];
-    this['x'] = this['y'];
-    this['y'] = -x;
-    return this;
-  };
-
-  // Rotate this vector (counter-clockwise) by the specified angle (in radians).
-  /**
-   * @param {number} angle The angle to rotate (in radians)
-   * @return {Vector} This for chaining.
-   */
-  Vector.prototype['rotate'] = Vector.prototype.rotate = function (angle) {
-    var x = this['x'];
-    var y = this['y'];
-    this['x'] = x * Math.cos(angle) - y * Math.sin(angle);
-    this['y'] = x * Math.sin(angle) + y * Math.cos(angle);
-    return this;
-  };
-
-  // Reverse this vector.
-  /**
-   * @return {Vector} This for chaining.
-   */
-  Vector.prototype['reverse'] = Vector.prototype.reverse = function() {
-    this['x'] = -this['x'];
-    this['y'] = -this['y'];
-    return this;
-  };
-
-
-  // Normalize this vector.  (make it have length of `1`)
-  /**
-   * @return {Vector} This for chaining.
-   */
-  Vector.prototype['normalize'] = Vector.prototype.normalize = function() {
-    var d = this.len();
-    if(d > 0) {
-      this['x'] = this['x'] / d;
-      this['y'] = this['y'] / d;
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
     }
-    return this;
-  };
-
-  // Add another vector to this one.
-  /**
-   * @param {Vector} other The other Vector.
-   * @return {Vector} This for chaining.
-   */
-  Vector.prototype['add'] = Vector.prototype.add = function(other) {
-    this['x'] += other['x'];
-    this['y'] += other['y'];
-    return this;
-  };
-
-  // Subtract another vector from this one.
-  /**
-   * @param {Vector} other The other Vector.
-   * @return {Vector} This for chaiing.
-   */
-  Vector.prototype['sub'] = Vector.prototype.sub = function(other) {
-    this['x'] -= other['x'];
-    this['y'] -= other['y'];
-    return this;
-  };
-
-  // Scale this vector. An independent scaling factor can be provided
-  // for each axis, or a single scaling factor that will scale both `x` and `y`.
-  /**
-   * @param {number} x The scaling factor in the x direction.
-   * @param {?number=} y The scaling factor in the y direction.  If this
-   *   is not specified, the x scaling factor will be used.
-   * @return {Vector} This for chaining.
-   */
-  Vector.prototype['scale'] = Vector.prototype.scale = function(x,y) {
-    this['x'] *= x;
-    this['y'] *= typeof y != 'undefined' ? y : x;
-    return this;
-  };
-
-  // Project this vector on to another vector.
-  /**
-   * @param {Vector} other The vector to project onto.
-   * @return {Vector} This for chaining.
-   */
-  Vector.prototype['project'] = Vector.prototype.project = function(other) {
-    var amt = this.dot(other) / other.len2();
-    this['x'] = amt * other['x'];
-    this['y'] = amt * other['y'];
-    return this;
-  };
-
-  // Project this vector onto a vector of unit length. This is slightly more efficient
-  // than `project` when dealing with unit vectors.
-  /**
-   * @param {Vector} other The unit vector to project onto.
-   * @return {Vector} This for chaining.
-   */
-  Vector.prototype['projectN'] = Vector.prototype.projectN = function(other) {
-    var amt = this.dot(other);
-    this['x'] = amt * other['x'];
-    this['y'] = amt * other['y'];
-    return this;
-  };
-
-  // Reflect this vector on an arbitrary axis.
-  /**
-   * @param {Vector} axis The vector representing the axis.
-   * @return {Vector} This for chaining.
-   */
-  Vector.prototype['reflect'] = Vector.prototype.reflect = function(axis) {
-    var x = this['x'];
-    var y = this['y'];
-    this.project(axis).scale(2);
-    this['x'] -= x;
-    this['y'] -= y;
-    return this;
-  };
-
-  // Reflect this vector on an arbitrary axis (represented by a unit vector). This is
-  // slightly more efficient than `reflect` when dealing with an axis that is a unit vector.
-  /**
-   * @param {Vector} axis The unit vector representing the axis.
-   * @return {Vector} This for chaining.
-   */
-  Vector.prototype['reflectN'] = Vector.prototype.reflectN = function(axis) {
-    var x = this['x'];
-    var y = this['y'];
-    this.projectN(axis).scale(2);
-    this['x'] -= x;
-    this['y'] -= y;
-    return this;
-  };
-
-  // Get the dot product of this vector and another.
-  /**
-   * @param {Vector}  other The vector to dot this one against.
-   * @return {number} The dot product.
-   */
-  Vector.prototype['dot'] = Vector.prototype.dot = function(other) {
-    return this['x'] * other['x'] + this['y'] * other['y'];
-  };
-
-  // Get the squared length of this vector.
-  /**
-   * @return {number} The length^2 of this vector.
-   */
-  Vector.prototype['len2'] = Vector.prototype.len2 = function() {
-    return this.dot(this);
-  };
-
-  // Get the length of this vector.
-  /**
-   * @return {number} The length of this vector.
-   */
-  Vector.prototype['len'] = Vector.prototype.len = function() {
-    return Math.sqrt(this.len2());
-  };
-
-  // ## Circle
-  //
-  // Represents a circle with a position and a radius.
-
-  // Create a new circle, optionally passing in a position and/or radius. If no position
-  // is given, the circle will be at `(0,0)`. If no radius is provided, the circle will
-  // have a radius of `0`.
-  /**
-   * @param {Vector=} pos A vector representing the position of the center of the circle
-   * @param {?number=} r The radius of the circle
-   * @constructor
-   */
-  function Circle(pos, r) {
-    this['pos'] = pos || new Vector();
-    this['r'] = r || 0;
-    this['offset'] = new Vector();
   }
-  SAT['Circle'] = Circle;
 
-  // Compute the axis-aligned bounding box (AABB) of this Circle.
-  //
-  // Note: Returns a _new_ `Polygon` each time you call this.
-  /**
-   * @return {Polygon} The AABB
-   */
-  Circle.prototype['getAABB'] = Circle.prototype.getAABB = function() {
-    var r = this['r'];
-    var corner = this['pos'].clone().add(this['offset']).sub(new Vector(r, r));
-    return new Box(corner, r*2, r*2).toPolygon();
-  };
-
-  // Set the current offset to apply to the radius.
-  /**
-   * @param {Vector} offset The new offset vector.
-   * @return {Circle} This for chaining.
-   */
-  Circle.prototype['setOffset'] = Circle.prototype.setOffset = function(offset) {
-    this['offset'] = offset;
-    return this;
-  };
-
-  // ## Polygon
-  //
-  // Represents a *convex* polygon with any number of points (specified in counter-clockwise order)
-  //
-  // Note: Do _not_ manually change the `points`, `angle`, or `offset` properties. Use the
-  // provided setters. Otherwise the calculated properties will not be updated correctly.
-  //
-  // `pos` can be changed directly.
-
-  // Create a new polygon, passing in a position vector, and an array of points (represented
-  // by vectors relative to the position vector). If no position is passed in, the position
-  // of the polygon will be `(0,0)`.
-  /**
-   * @param {Vector=} pos A vector representing the origin of the polygon. (all other
-   *   points are relative to this one)
-   * @param {Array<Vector>=} points An array of vectors representing the points in the polygon,
-   *   in counter-clockwise order.
-   * @constructor
-   */
-  function Polygon(pos, points) {
-    this['pos'] = pos || new Vector();
-    this['angle'] = 0;
-    this['offset'] = new Vector();
-    this.setPoints(points || []);
+  function _defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      if ("value" in descriptor) descriptor.writable = true;
+      Object.defineProperty(target, descriptor.key, descriptor);
+    }
   }
-  SAT['Polygon'] = Polygon;
 
-  // Set the points of the polygon. Any consecutive duplicate points will be combined.
-  //
-  // Note: The points are counter-clockwise *with respect to the coordinate system*.
-  // If you directly draw the points on a screen that has the origin at the top-left corner
-  // it will _appear_ visually that the points are being specified clockwise. This is just
-  // because of the inversion of the Y-axis when being displayed.
-  /**
-   * @param {Array<Vector>=} points An array of vectors representing the points in the polygon,
-   *   in counter-clockwise order.
-   * @return {Polygon} This for chaining.
-   */
-  Polygon.prototype['setPoints'] = Polygon.prototype.setPoints = function(points) {
-    // Only re-allocate if this is a new polygon or the number of points has changed.
-    var lengthChanged = !this['points'] || this['points'].length !== points.length;
-    if (lengthChanged) {
-      var i;
-      var calcPoints = this['calcPoints'] = [];
-      var edges = this['edges'] = [];
-      var normals = this['normals'] = [];
-      // Allocate the vector arrays for the calculated properties
-      for (i = 0; i < points.length; i++) {
-        // Remove consecutive duplicate points
-        var p1 = points[i];
-        var p2 = i < points.length - 1 ? points[i + 1] : points[0];
-        if (p1 !== p2 && p1.x === p2.x && p1.y === p2.y) {
-          points.splice(i, 1);
-          i -= 1;
-          continue;
+  function _createClass(Constructor, protoProps, staticProps) {
+    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) _defineProperties(Constructor, staticProps);
+    return Constructor;
+  }
+
+  function _readOnlyError(name) {
+    throw new Error("\"" + name + "\" is read-only");
+  }
+
+  var Vector =
+  /*#__PURE__*/
+  function () {
+    /**
+     * @param {number} [x=0] The x coordinate of this Vector.
+     * @param {number} [y=0] The y coordinate of this Vector.
+     */
+    function Vector() {
+      var x = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
+      var y = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+
+      _classCallCheck(this, Vector);
+
+      this.x = x;
+      this.y = y;
+    }
+    /**
+     * Copy the values of another Vector into this one.
+     * 
+     * @param {*} other The other Vector.
+     * 
+     * @returns {Vector} Returns this for chaining.
+     */
+
+
+    _createClass(Vector, [{
+      key: "copy",
+      value: function copy(other) {
+        this.x = other.x;
+        this.y = other.y;
+        return this;
+      }
+      /**
+       * Create a new Vector with the same coordinates as the one.
+       * 
+       * @returns {Vector} The new cloned Vector.
+       */
+
+    }, {
+      key: "clone",
+      value: function clone() {
+        return new Vector(this.x, this.y);
+      }
+      /**
+       * Change this Vector to be perpendicular to what it was before.
+       * 
+       * Effectively this rotates it 90 degrees in a clockwise direction.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "perp",
+      value: function perp() {
+        var x = this.x;
+        this.x = this.y;
+        this.y = -x;
+        return this;
+      }
+      /**
+       * Rotate this Vector (counter-clockwise) by the specified angle (in radians).
+       * 
+       * @param {number} angle The angle to rotate (in radians).
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "rotate",
+      value: function rotate(angle) {
+        var x = this.x;
+        var y = this.y;
+        this.x = x * Math.cos(angle) - y * Math.sin(angle);
+        this.y = x * Math.sin(angle) + y * Math.cos(angle);
+        return this;
+      }
+      /**
+       * Reverse this Vector.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "reverse",
+      value: function reverse() {
+        this.x = -this.x;
+        this.y = -this.y;
+        return this;
+      }
+      /**
+       * Normalize this vector (make it have a length of `1`).
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "normalize",
+      value: function normalize() {
+        var d = this.len();
+
+        if (d > 0) {
+          this.x = this.x / d;
+          this.y = this.y / d;
         }
-        calcPoints.push(new Vector());
-        edges.push(new Vector());
-        normals.push(new Vector());
+
+        return this;
       }
-    }
-    this['points'] = points;
-    this._recalc();
-    return this;
-  };
+      /**
+       * Add another Vector to this one.
+       * 
+       * @param {Vector} other The other Vector.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
 
-  // Set the current rotation angle of the polygon.
-  /**
-   * @param {number} angle The current rotation angle (in radians).
-   * @return {Polygon} This for chaining.
-   */
-  Polygon.prototype['setAngle'] = Polygon.prototype.setAngle = function(angle) {
-    this['angle'] = angle;
-    this._recalc();
-    return this;
-  };
-
-  // Set the current offset to apply to the `points` before applying the `angle` rotation.
-  /**
-   * @param {Vector} offset The new offset vector.
-   * @return {Polygon} This for chaining.
-   */
-  Polygon.prototype['setOffset'] = Polygon.prototype.setOffset = function(offset) {
-    this['offset'] = offset;
-    this._recalc();
-    return this;
-  };
-
-  // Rotates this polygon counter-clockwise around the origin of *its local coordinate system* (i.e. `pos`).
-  //
-  // Note: This changes the **original** points (so any `angle` will be applied on top of this rotation).
-  /**
-   * @param {number} angle The angle to rotate (in radians)
-   * @return {Polygon} This for chaining.
-   */
-  Polygon.prototype['rotate'] = Polygon.prototype.rotate = function(angle) {
-    var points = this['points'];
-    var len = points.length;
-    for (var i = 0; i < len; i++) {
-      points[i].rotate(angle);
-    }
-    this._recalc();
-    return this;
-  };
-
-  // Translates the points of this polygon by a specified amount relative to the origin of *its own coordinate
-  // system* (i.e. `pos`).
-  //
-  // This is most useful to change the "center point" of a polygon. If you just want to move the whole polygon, change
-  // the coordinates of `pos`.
-  //
-  // Note: This changes the **original** points (so any `offset` will be applied on top of this translation)
-  /**
-   * @param {number} x The horizontal amount to translate.
-   * @param {number} y The vertical amount to translate.
-   * @return {Polygon} This for chaining.
-   */
-  Polygon.prototype['translate'] = Polygon.prototype.translate = function (x, y) {
-    var points = this['points'];
-    var len = points.length;
-    for (var i = 0; i < len; i++) {
-      points[i]["x"] += x;
-      points[i]["y"] += y;
-    }
-    this._recalc();
-    return this;
-  };
-
-
-  // Computes the calculated collision polygon. Applies the `angle` and `offset` to the original points then recalculates the
-  // edges and normals of the collision polygon.
-  /**
-   * @return {Polygon} This for chaining.
-   */
-  Polygon.prototype._recalc = function() {
-    // Calculated points - this is what is used for underlying collisions and takes into account
-    // the angle/offset set on the polygon.
-    var calcPoints = this['calcPoints'];
-    // The edges here are the direction of the `n`th edge of the polygon, relative to
-    // the `n`th point. If you want to draw a given edge from the edge value, you must
-    // first translate to the position of the starting point.
-    var edges = this['edges'];
-    // The normals here are the direction of the normal for the `n`th edge of the polygon, relative
-    // to the position of the `n`th point. If you want to draw an edge normal, you must first
-    // translate to the position of the starting point.
-    var normals = this['normals'];
-    // Copy the original points array and apply the offset/angle
-    var points = this['points'];
-    var offset = this['offset'];
-    var angle = this['angle'];
-    var len = points.length;
-    var i;
-    for (i = 0; i < len; i++) {
-      var calcPoint = calcPoints[i].copy(points[i]);
-      calcPoint["x"] += offset["x"];
-      calcPoint["y"] += offset["y"];
-      if (angle !== 0) {
-        calcPoint.rotate(angle);
+    }, {
+      key: "add",
+      value: function add(other) {
+        this.x += other.x;
+        this.y += other.y;
+        return this;
       }
-    }
-    // Calculate the edges/normals
-    for (i = 0; i < len; i++) {
-      var p1 = calcPoints[i];
-      var p2 = i < len - 1 ? calcPoints[i + 1] : calcPoints[0];
-      var e = edges[i].copy(p2).sub(p1);
-      normals[i].copy(e).perp().normalize();
-    }
-    return this;
-  };
+      /**
+       * Subtract another Vector from this one.
+       * 
+       * @param {Vector} other The other Vector.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
 
-
-  // Compute the axis-aligned bounding box. Any current state
-  // (translations/rotations) will be applied before constructing the AABB.
-  //
-  // Note: Returns a _new_ `Polygon` each time you call this.
-  /**
-   * @return {Polygon} The AABB
-   */
-  Polygon.prototype["getAABB"] = Polygon.prototype.getAABB = function() {
-    var points = this["calcPoints"];
-    var len = points.length;
-    var xMin = points[0]["x"];
-    var yMin = points[0]["y"];
-    var xMax = points[0]["x"];
-    var yMax = points[0]["y"];
-    for (var i = 1; i < len; i++) {
-      var point = points[i];
-      if (point["x"] < xMin) {
-        xMin = point["x"];
+    }, {
+      key: "sub",
+      value: function sub(other) {
+        this.x -= other.x;
+        this.y -= other.y;
+        return this;
       }
-      else if (point["x"] > xMax) {
-        xMax = point["x"];
+      /**
+       * Scale this Vector.
+       * 
+       * An independent scaling factor can be provided for each axis, or a single scaling factor will scale
+       * both `x` and `y`.
+       * 
+       * @param {number} x The scaling factor in the x direction.
+       * @param {number} [y] The scaling factor in the y direction.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "scale",
+      value: function scale(x, y) {
+        this.x *= x;
+        this.y *= typeof y != 'undefined' ? y : x;
+        return this;
       }
-      if (point["y"] < yMin) {
-        yMin = point["y"];
+      /**
+       * Project this Vector onto another Vector.
+       * 
+       * @param {Vector} other The Vector to project onto.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "project",
+      value: function project(other) {
+        var amt = this.dot(other) / other.len2();
+        this.x = amt * other.x;
+        this.y = amt * other.y;
+        return this;
       }
-      else if (point["y"] > yMax) {
-        yMax = point["y"];
+      /**
+       * Project this Vector onto a Vector of unit length.
+       * 
+       * This is slightly more efficient than `project` when dealing with unit vectors.
+       * 
+       * @param {Vector} other The unit vector to project onto.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "projectN",
+      value: function projectN(other) {
+        var amt = this.dot(other);
+        this.x = amt * other.x;
+        this.y = amt * other.y;
+        return this;
       }
+      /**
+       * Reflect this Vector on an arbitrary axis.
+       * 
+       * @param {Vector} axis The Vector representing the axis.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "reflect",
+      value: function reflect(axis) {
+        var x = this.x;
+        var y = this.y;
+        this.project(axis).scale(2);
+        this.x -= x;
+        this.y -= y;
+        return this;
+      }
+      /**
+       * Reflect this Vector on an arbitrary axis.
+       * 
+       * This is slightly more efficient than `reflect` when dealing with an axis that is a unit vector.
+       * 
+       * @param {Vector} axis The Vector representing the axis.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "reflectN",
+      value: function reflectN(axis) {
+        var x = this.x;
+        var y = this.y;
+        this.projectN(axis).scale(2);
+        this.x -= x;
+        this.y -= y;
+        return this;
+      }
+      /**
+       * Get the dot product of this Vector and another.
+       * 
+       * @param {Vector} other The Vector to dot this one against.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "dot",
+      value: function dot(other) {
+        return this.x * other.x + this.y * other.y;
+      }
+      /**
+       * Get the squared length of this Vector.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "len2",
+      value: function len2() {
+        return this.dot(this);
+      }
+      /**
+       * Get the length of this Vector.
+       * 
+       * @returns {Vector} Returns this for chaining.
+       */
+
+    }, {
+      key: "len",
+      value: function len() {
+        return Math.sqrt(this.len2());
+      }
+    }]);
+
+    return Vector;
+  }();
+
+  /**
+   * ## Polygon
+   * 
+   * Represents a *convex* polygon with any number of points (specified in counter-clockwise order).
+   * 
+   * Note: Do _not_ manually change the `points`, `angle`, or `offset` properties. Use the provided 
+   * setters. Otherwise the calculated properties will not be updated correctly.
+   * 
+   * `pos` can be changed directly.
+   */
+
+  var Polygon =
+  /*#__PURE__*/
+  function () {
+    /**
+     * Create a new polygon, passing in a position vector, and an array of points (represented by vectors 
+     * relative to the position vector). If no position is passed in, the position of the polygon will be `(0,0)`.
+     * 
+     * @param {Vector} [pos=Vector] A vector representing the origin of the polygon (all other points are relative to this one)
+     * @param {Array<Vector>} [points=[]] An array of vectors representing the points in the polygon, in counter-clockwise order.
+     */
+    function Polygon() {
+      var pos = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : new Vector();
+      var points = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
+
+      _classCallCheck(this, Polygon);
+
+      this.pos = pos;
+      this.angle = 0;
+      this.offset = new Vector();
+      this.setPoints(points);
     }
-    return new Box(this['pos'].clone().add(new Vector(xMin, yMin)), xMax - xMin, yMax - yMin).toPolygon();
-  };
+    /**
+     * Set the points of the polygon. Any consecutive duplicate points will be combined.
+     * 
+     * Note: The points are counter-clockwise *with respect to the coordinate system*. If you directly draw the points on a screen 
+     * that has the origin at the top-left corner it will _appear_ visually that the points are being specified clockwise. This is 
+     * just because of the inversion of the Y-axis when being displayed.
+     * 
+     * @param {Array<Vector>} points An array of vectors representing the points in the polygon, in counter-clockwise order.
+     * 
+     * @returns {Polygon} Returns this for chaining.
+     */
 
-  // Compute the centroid (geometric center) of the polygon. Any current state
-  // (translations/rotations) will be applied before computing the centroid.
-  //
-  // See https://en.wikipedia.org/wiki/Centroid#Centroid_of_a_polygon
-  //
-  // Note: Returns a _new_ `Vector` each time you call this.
+
+    _createClass(Polygon, [{
+      key: "setPoints",
+      value: function setPoints(points) {
+        // Only re-allocate if this is a new polygon or the number of points has changed.
+        var lengthChanged = !this.points || this.points.length !== points.length;
+
+        if (lengthChanged) {
+          var i;
+          var calcPoints = this.calcPoints = [];
+          var edges = this.edges = [];
+          var normals = this.normals = []; // Allocate the vector arrays for the calculated properties
+
+          for (i = 0; i < points.length; i++) {
+            // Remove consecutive duplicate points
+            var p1 = points[i];
+            var p2 = i < points.length - 1 ? points[i + 1] : points[0];
+
+            if (p1 !== p2 && p1.x === p2.x && p1.y === p2.y) {
+              points.splice(i, 1);
+              i -= 1;
+              continue;
+            }
+
+            calcPoints.push(new Vector());
+            edges.push(new Vector());
+            normals.push(new Vector());
+          }
+        }
+
+        this.points = points;
+
+        this._recalc();
+
+        return this;
+      }
+      /**
+       * Set the current rotation angle of the polygon.
+       * 
+       * @param {number} angle The current rotation angle (in radians).
+       * 
+       * @returns {Polygon} Returns this for chaining.
+       */
+
+    }, {
+      key: "setAngle",
+      value: function setAngle(angle) {
+        this.angle = angle;
+
+        this._recalc();
+
+        return this;
+      }
+      /**
+       * Set the current offset to apply to the `points` before applying the `angle` rotation.
+       * 
+       * @param {Vector} offset The new offset Vector.
+       * 
+       * @returns {Polygon} Returns this for chaining.
+       */
+
+    }, {
+      key: "setOffset",
+      value: function setOffset(offset) {
+        this.offset = offset;
+
+        this._recalc();
+
+        return this;
+      }
+      /**
+       * Rotates this Polygon counter-clockwise around the origin of *its local coordinate system* (i.e. `pos`).
+       * 
+       * Note: This changes the **original** points (so any `angle` will be applied on top of this rotation).
+       * 
+       * @param {number} angle The angle to rotate (in radians).
+       * 
+       * @returns {Polygon} Returns this for chaining.
+       */
+
+    }, {
+      key: "rotate",
+      value: function rotate(angle) {
+        var points = this.points;
+        var len = points.length;
+
+        for (var i = 0; i < len; i++) {
+          points[i].rotate(angle);
+        }
+
+        this._recalc();
+
+        return this;
+      }
+      /**
+       * Translates the points of this polygon by a specified amount relative to the origin of *its own coordinate system* (i.e. `pos`).
+       * 
+       * Note: This changes the **original** points (so any `offset` will be applied on top of this translation)
+       * 
+       * @param {number} x The horizontal amount to translate.
+       * @param {number} y The vertical amount to translate.
+       * 
+       * @returns {Polygon} Returns this for chaining.
+       */
+
+    }, {
+      key: "translate",
+      value: function translate(x, y) {
+        var points = this.points;
+        var len = points.length;
+
+        for (var i = 0; i < len; i++) {
+          points[i].x += x;
+          points[i].y += y;
+        }
+
+        this._recalc();
+
+        return this;
+      }
+      /**
+       * Computes the calculated collision Polygon.
+       * 
+       * This applies the `angle` and `offset` to the original points then recalculates the edges and normals of the collision Polygon.
+       * 
+       * @private
+       * 
+       * @returns {Polygon} Returns this for chaining.
+       */
+
+    }, {
+      key: "_recalc",
+      value: function _recalc() {
+        // Calculated points - this is what is used for underlying collisions and takes into account
+        // the angle/offset set on the polygon.
+        var calcPoints = this.calcPoints; // The edges here are the direction of the `n`th edge of the polygon, relative to
+        // the `n`th point. If you want to draw a given edge from the edge value, you must
+        // first translate to the position of the starting point.
+
+        var edges = this.edges; // The normals here are the direction of the normal for the `n`th edge of the polygon, relative
+        // to the position of the `n`th point. If you want to draw an edge normal, you must first
+        // translate to the position of the starting point.
+
+        var normals = this.normals; // Copy the original points array and apply the offset/angle
+
+        var points = this.points;
+        var offset = this.offset;
+        var angle = this.angle;
+        var len = points.length;
+        var i;
+
+        for (i = 0; i < len; i++) {
+          var calcPoint = calcPoints[i].copy(points[i]);
+          calcPoint.x += offset.x;
+          calcPoint.y += offset.y;
+          if (angle !== 0) calcPoint.rotate(angle);
+        } // Calculate the edges/normals
+
+
+        for (i = 0; i < len; i++) {
+          var p1 = calcPoints[i];
+          var p2 = i < len - 1 ? calcPoints[i + 1] : calcPoints[0];
+          var e = edges[i].copy(p2).sub(p1);
+          normals[i].copy(e).perp().normalize();
+        }
+
+        return this;
+      }
+      /**
+       * Compute the axis-aligned bounding box.
+       * 
+       * Any current state (translations/rotations) will be applied before constructing the AABB.
+       * 
+       * Note: Returns a _new_ `Polygon` each time you call this.
+       * 
+       * @returns {Polygon} Returns this for chaining.
+       */
+
+    }, {
+      key: "getAABB",
+      value: function getAABB() {
+        var points = this.calcPoints;
+        var len = points.length;
+        var xMin = points[0].x;
+        var yMin = points[0].y;
+        var xMax = points[0].x;
+        var yMax = points[0].y;
+
+        for (var i = 1; i < len; i++) {
+          var point = points[i];
+          if (point["x"] < xMin) xMin = (_readOnlyError("xMin"), point["x"]);else if (point["x"] > xMax) xMax = (_readOnlyError("xMax"), point["x"]);
+          if (point["y"] < yMin) yMin = (_readOnlyError("yMin"), point["y"]);else if (point["y"] > yMax) yMax = (_readOnlyError("yMax"), point["y"]);
+        }
+
+        return new Box(this['pos'].clone().add(new Vector(xMin, yMin)), xMax - xMin, yMax - yMin).toPolygon();
+      }
+      /**
+       * Compute the centroid (geometric center) of the Polygon.
+       * 
+       * Any current state (translations/rotations) will be applied before computing the centroid.
+       * 
+       * See https://en.wikipedia.org/wiki/Centroid#Centroid_of_a_polygon
+       * 
+       * Note: Returns a _new_ `Vector` each time you call this.
+       * 
+       * @returns {Vector} Returns a Vector that contains the coordinates of the centroid.
+       */
+
+    }, {
+      key: "getCentroid",
+      value: function getCentroid() {
+        var points = this.calcPoints;
+        var len = points.length;
+        var cx = 0;
+        var cy = 0;
+        var ar = 0;
+
+        for (var i = 0; i < len; i++) {
+          var p1 = points[i];
+          var p2 = i === len - 1 ? points[0] : points[i + 1]; // Loop around if last point
+
+          var a = p1["x"] * p2["y"] - p2["x"] * p1["y"];
+          cx += (p1["x"] + p2["x"]) * a;
+          cy += (p1["y"] + p2["y"]) * a;
+          ar += a;
+        }
+
+        ar = ar * 3; // we want 1 / 6 the area and we currently have 2*area
+
+        cx = cx / ar;
+        cy = cy / ar;
+        return new Vector(cx, cy);
+      }
+    }]);
+
+    return Polygon;
+  }();
+
   /**
-   * @return {Vector} A Vector that contains the coordinates of the Centroid.
+   * ## Box
+   * 
+   * Represents an axis-aligned box, with a width and height.
    */
-  Polygon.prototype["getCentroid"] = Polygon.prototype.getCentroid = function() {
-    var points = this["calcPoints"];
-    var len = points.length;
-    var cx = 0;
-    var cy = 0;
-    var ar = 0;
-    for (var i = 0; i < len; i++) {
-      var p1 = points[i];
-      var p2 = i === len - 1 ? points[0] : points[i+1]; // Loop around if last point
-      var a = p1["x"] * p2["y"] - p2["x"] * p1["y"];
-      cx += (p1["x"] + p2["x"]) * a;
-      cy += (p1["y"] + p2["y"]) * a;
-      ar += a;
+
+  var Box$1 =
+  /*#__PURE__*/
+  function () {
+    /**
+     * Creates a new Box, with the specified position, width, and height.
+     * 
+     * If no position is given, the position will be `(0, 0)`. If no width or height are given, they will
+     * be set to `0`.
+     * 
+     * @param {Vector} [pos=new Vector()] A Vector representing the bottom-left of the box(i.e. the smallest x and smallest y value).
+     * @param {number} [w=0] The width of the Box.
+     * @param {number} [h=0] The height of the Box.
+     */
+    function Box() {
+      var pos = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : new Vector();
+      var w = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+      var h = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
+
+      _classCallCheck(this, Box);
+
+      this.pos = pos;
+      this.w = w;
+      this.h = h;
     }
-    ar = ar * 3; // we want 1 / 6 the area and we currently have 2*area
-    cx = cx / ar;
-    cy = cy / ar;
-    return new Vector(cx, cy);
-  };
+    /**
+     * Returns a Polygon whose edges are the same as this Box.
+     * 
+     * @returns {Polygon} A new Polygon that represents this Box.
+     */
 
 
-  // ## Box
-  //
-  // Represents an axis-aligned box, with a width and height.
+    _createClass(Box, [{
+      key: "toPolygon",
+      value: function toPolygon() {
+        var pos = this.pos;
+        var w = this.w;
+        var h = this.h;
+        return new Polygon(new Vector(pos.x, pos.y), [new Vector(), new Vector(w, 0), new Vector(w, h), new Vector(0, h)]);
+      }
+    }]);
 
+    return Box;
+  }();
 
-  // Create a new box, with the specified position, width, and height. If no position
-  // is given, the position will be `(0,0)`. If no width or height are given, they will
-  // be set to `0`.
   /**
-   * @param {Vector=} pos A vector representing the bottom-left of the box (i.e. the smallest x and smallest y value).
-   * @param {?number=} w The width of the box.
-   * @param {?number=} h The height of the box.
-   * @constructor
+   * ## Circle
+   * 
+   * Represents a circle with a position and a radius.
+   * 
+   * Creates a new Circle, optionally passing in a position and/or radius. If no position
+   * is given, the Circle will be at `(0,0)`. If no radius is provided the circle will have
+   * a radius of `0`.
    */
-  function Box(pos, w, h) {
-    this['pos'] = pos || new Vector();
-    this['w'] = w || 0;
-    this['h'] = h || 0;
-  }
-  SAT['Box'] = Box;
 
-  // Returns a polygon whose edges are the same as this box.
+  var Circle =
+  /*#__PURE__*/
+  function () {
+    /**
+     * @param {Vector} pos A Vector representing the center of this Circle.
+     * @param {number} r The radius of this Circle. 
+     */
+    function Circle() {
+      var pos = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : new Vector();
+      var r = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+
+      _classCallCheck(this, Circle);
+
+      this.pos = pos;
+      this.r = r;
+      this.offset = new Vector();
+    }
+    /**
+     * Compute the axis-aligned bounding box (AABB) of this Circle.
+     * 
+     * Note: Returns a _new_ `Polygon` each time you call this.
+     * 
+     * @returns {Polygon} Returns the AABB.
+     */
+
+
+    _createClass(Circle, [{
+      key: "getAABB",
+      value: function getAABB() {
+        var r = this.r;
+        var corner = this.pos.clone().add(this.offset).sub(new Vector(r, r));
+        return new Box(corner, r * 2, r * 2).toPolygon();
+      }
+      /**
+       * Set the current offset to apply to the radius.
+       * 
+       * @param {Vector} offset The new offset Vector.
+       * 
+       * @returns {Circle} Returns this for chaining.
+       */
+
+    }, {
+      key: "setOffset",
+      value: function setOffset(offset) {
+        this.offset = offset;
+        return this;
+      }
+    }]);
+
+    return Circle;
+  }();
+
   /**
-   * @return {Polygon} A new Polygon that represents this box.
+   * ## Response
+   * 
+   * An object representing the result of an intersection. Contains:
+   * - The two objects participating in the intersection
+   * - The vector representing the minimum change necessary to extract the first object from the second one (as well as a unit vector in that direction and the magnitude of the overlap)
+   * - Whether the first object is entirely inside the second, and vice versa.
    */
-  Box.prototype['toPolygon'] = Box.prototype.toPolygon = function() {
-    var pos = this['pos'];
-    var w = this['w'];
-    var h = this['h'];
-    return new Polygon(new Vector(pos['x'], pos['y']), [
-     new Vector(), new Vector(w, 0),
-     new Vector(w,h), new Vector(0,h)
-    ]);
-  };
 
-  // ## Response
-  //
-  // An object representing the result of an intersection. Contains:
-  //  - The two objects participating in the intersection
-  //  - The vector representing the minimum change necessary to extract the first object
-  //    from the second one (as well as a unit vector in that direction and the magnitude
-  //    of the overlap)
-  //  - Whether the first object is entirely inside the second, and vice versa.
+  var Response =
+  /*#__PURE__*/
+  function () {
+    function Response() {
+      _classCallCheck(this, Response);
+
+      this.a = null;
+      this.b = null;
+      this.overlapN = new Vector();
+      this.overlapV = new Vector();
+      this.clear();
+    }
+    /**
+     * Set some values of the response back to their defaults.
+     * 
+     * Call this between tests if you are going to reuse a single Response object for multiple intersection tests (recommended as it will avoid allcating extra memory)
+     * 
+     * @returns {Response} Returns this for chaining.
+     */
+
+
+    _createClass(Response, [{
+      key: "clear",
+      value: function clear() {
+        this.aInB = true;
+        this.bInA = true;
+        this.overlap = Number.MAX_VALUE;
+        return this;
+      }
+    }]);
+
+    return Response;
+  }();
+
   /**
-   * @constructor
+   * ## Object Pools
    */
-  function Response() {
-    this['a'] = null;
-    this['b'] = null;
-    this['overlapN'] = new Vector();
-    this['overlapV'] = new Vector();
-    this.clear();
-  }
-  SAT['Response'] = Response;
 
-  // Set some values of the response back to their defaults.  Call this between tests if
-  // you are going to reuse a single Response object for multiple intersection tests (recommented
-  // as it will avoid allcating extra memory)
   /**
-   * @return {Response} This for chaining
-   */
-  Response.prototype['clear'] = Response.prototype.clear = function() {
-    this['aInB'] = true;
-    this['bInA'] = true;
-    this['overlap'] = Number.MAX_VALUE;
-    return this;
-  };
-
-  // ## Object Pools
-
-  // A pool of `Vector` objects that are used in calculations to avoid
-  // allocating memory.
-  /**
+   * A pool of `Vector objects that are used in calculations to avoid allocating memory.
+   * 
    * @type {Array<Vector>}
    */
-  var T_VECTORS = [];
-  for (var i = 0; i < 10; i++) { T_VECTORS.push(new Vector()); }
 
-  // A pool of arrays of numbers used in calculations to avoid allocating
-  // memory.
+  var T_VECTORS = [];
+
+  for (var i = 0; i < 10; i++) {
+    T_VECTORS.push(new Vector());
+  }
   /**
+   * A pool of arrays of numbers used in calculations to avoid allocating memory.
+   * 
    * @type {Array<Array<number>>}
    */
-  var T_ARRAYS = [];
-  for (var i = 0; i < 5; i++) { T_ARRAYS.push([]); }
 
-  // Temporary response used for polygon hit detection.
+
+  var T_ARRAYS = [];
+
+  for (var _i = 0; _i < 5; _i++) {
+    T_ARRAYS.push([]);
+  }
   /**
+   * Temporary response used for Polygon hit detection.
+   * 
    * @type {Response}
    */
-  var T_RESPONSE = new Response();
 
-  // Tiny "point" polygon used for polygon hit detection.
+
+  var T_RESPONSE = new Response();
   /**
+   * Tiny "point" Polygon used for Polygon hit detection.
+   * 
    * @type {Polygon}
    */
-  var TEST_POINT = new Box(new Vector(), 0.000001, 0.000001).toPolygon();
 
-  // ## Helper Functions
-
-  // Flattens the specified array of points onto a unit vector axis,
-  // resulting in a one dimensional range of the minimum and
-  // maximum value on that axis.
+  var TEST_POINT = new Box$1(new Vector(), 0.000001, 0.000001).toPolygon();
   /**
+   * ## Constants for Voronoi regions.
+   */
+
+  var LEFT_VORONOI_REGION = -1;
+  var MIDDLE_VORONOI_REGION = 0;
+  var RIGHT_VORONOI_REGION = 1;
+  /**
+   * ## Helper Functions
+   */
+
+  /**
+   * Flattens the specified array of points onto a unit vector axis resulting in a one dimensionsl
+   * range of the minimum and maximum value on that axis.
+   * 
    * @param {Array<Vector>} points The points to flatten.
    * @param {Vector} normal The unit vector axis to flatten on.
-   * @param {Array<number>} result An array.  After calling this function,
-   *   result[0] will be the minimum value,
-   *   result[1] will be the maximum value.
+   * @param {Array<number>} result An array. After calling this function, result[0] will be the minimum value, result[1] will be the maximum value.
    */
+
   function flattenPointsOn(points, normal, result) {
     var min = Number.MAX_VALUE;
     var max = -Number.MAX_VALUE;
     var len = points.length;
-    for (var i = 0; i < len; i++ ) {
-      // The magnitude of the projection of the point onto the normal
-      var dot = points[i].dot(normal);
-      if (dot < min) { min = dot; }
-      if (dot > max) { max = dot; }
+
+    for (var _i2 = 0; _i2 < len; _i2++) {
+      // The magnitude of the projection of the point onto the normal.
+      var dot = points[_i2].dot(normal);
+
+      if (dot < min) min = dot;
+      if (dot > max) max = dot;
     }
-    result[0] = min; result[1] = max;
+
+    result[0] = min;
+    result[1] = max;
+  }
+  /**
+   * Calculates which Voronoi region a point is on a line segment.
+   * 
+   * It is assumed that both the line and the point are relative to `(0,0)`
+   * 
+   *             |       (0)      |
+   *      (-1)  [S]--------------[E]  (1)
+   *            |       (0)      |
+   * 
+   * @param {Vector} line The line segment.
+   * @param {Vector} point The point.
+   * @return {number} LEFT_VORONOI_REGION (-1) if it is the left region,
+   *                  MIDDLE_VORONOI_REGION (0) if it is the middle region,
+   *                  RIGHT_VORONOI_REGION (1) if it is the right region.
+   */
+
+
+  function voronoiRegion(line, point) {
+    var len2 = line.len2();
+    var dp = point.dot(line); // If the point is beyond the start of the line, it is in the left voronoi region.
+
+    if (dp < 0) return LEFT_VORONOI_REGION; // If the point is beyond the end of the line, it is in the right voronoi region.
+    else if (dp > len2) return RIGHT_VORONOI_REGION; // Otherwise, it's in the middle one.
+      else return MIDDLE_VORONOI_REGION;
   }
 
-  // Check whether two convex polygons are separated by the specified
-  // axis (must be a unit vector).
-  /**
-   * @param {Vector} aPos The position of the first polygon.
-   * @param {Vector} bPos The position of the second polygon.
-   * @param {Array<Vector>} aPoints The points in the first polygon.
-   * @param {Array<Vector>} bPoints The points in the second polygon.
-   * @param {Vector} axis The axis (unit sized) to test against.  The points of both polygons
-   *   will be projected onto this axis.
-   * @param {Response=} response A Response object (optional) which will be populated
-   *   if the axis is not a separating axis.
-   * @return {boolean} true if it is a separating axis, false otherwise.  If false,
-   *   and a response is passed in, information about how much overlap and
-   *   the direction of the overlap will be populated.
-   */
-  function isSeparatingAxis(aPos, bPos, aPoints, bPoints, axis, response) {
-    var rangeA = T_ARRAYS.pop();
-    var rangeB = T_ARRAYS.pop();
-    // The magnitude of the offset between the two polygons
-    var offsetV = T_VECTORS.pop().copy(bPos).sub(aPos);
-    var projectedOffset = offsetV.dot(axis);
-    // Project the polygons onto the axis.
-    flattenPointsOn(aPoints, axis, rangeA);
-    flattenPointsOn(bPoints, axis, rangeB);
-    // Move B's range to its position relative to A.
-    rangeB[0] += projectedOffset;
-    rangeB[1] += projectedOffset;
-    // Check if there is a gap. If there is, this is a separating axis and we can stop
-    if (rangeA[0] > rangeB[1] || rangeB[0] > rangeA[1]) {
+  var index = {
+    Box: Box$1,
+    Vector: Vector,
+    Circle: Circle,
+    Polygon: Polygon,
+    Response: Response,
+    V: Vector,
+
+    /**
+     * Check whether two convex polygons are separated by the specified axis (must be a unit vector).
+     * 
+     * @param {Vector} aPos The position of the first polygon.
+     * @param {Vector} bPos The position of the second polygon.
+     * @param {Array<Vector>} aPoints The points in the first polygon.
+     * @param {Array<Vector>} bPoints The points in the second polygon.
+     * @param {Vector} axis The axis (unit sized) to test against.  The points of both polygons will be projected onto this axis.
+     * @param {Response=} response A Response object (optional) which will be populated if the axis is not a separating axis.
+     * @return {boolean} true if it is a separating axis, false otherwise.  If false, and a response is passed in, information about how much overlap and the direction of the overlap will be populated.
+     */
+    isSeparatingAxis: function isSeparatingAxis(aPos, bPos, aPoints, bPoints, axis, response) {
+      var rangeA = T_ARRAYS.pop();
+      var rangeB = T_ARRAYS.pop(); // The magnitude of the offset between the two polygons
+
+      var offsetV = T_VECTORS.pop().copy(bPos).sub(aPos);
+      var projectedOffset = offsetV.dot(axis); // Project the polygons onto the axis.
+
+      flattenPointsOn(aPoints, axis, rangeA);
+      flattenPointsOn(bPoints, axis, rangeB); // Move B's range to its position relative to A.
+
+      rangeB[0] += projectedOffset;
+      rangeB[1] += projectedOffset; // Check if there is a gap. If there is, this is a separating axis and we can stop
+
+      if (rangeA[0] > rangeB[1] || rangeB[0] > rangeA[1]) {
+        T_VECTORS.push(offsetV);
+        T_ARRAYS.push(rangeA);
+        T_ARRAYS.push(rangeB);
+        return true;
+      } // This is not a separating axis. If we're calculating a response, calculate the overlap.
+
+
+      if (response) {
+        var overlap = 0; // A starts further left than B
+
+        if (rangeA[0] < rangeB[0]) {
+          response['aInB'] = false; // A ends before B does. We have to pull A out of B
+
+          if (rangeA[1] < rangeB[1]) {
+            overlap = rangeA[1] - rangeB[0];
+            response['bInA'] = false; // B is fully inside A.  Pick the shortest way out.
+          } else {
+            var option1 = rangeA[1] - rangeB[0];
+            var option2 = rangeB[1] - rangeA[0];
+            overlap = option1 < option2 ? option1 : -option2;
+          } // B starts further left than A
+
+        } else {
+          response['bInA'] = false; // B ends before A ends. We have to push A out of B
+
+          if (rangeA[1] > rangeB[1]) {
+            overlap = rangeA[0] - rangeB[1];
+            response['aInB'] = false; // A is fully inside B.  Pick the shortest way out.
+          } else {
+            var _option = rangeA[1] - rangeB[0];
+
+            var _option2 = rangeB[1] - rangeA[0];
+
+            overlap = _option < _option2 ? _option : -_option2;
+          }
+        } // If this is the smallest amount of overlap we've seen so far, set it as the minimum overlap.
+
+
+        var absOverlap = Math.abs(overlap);
+
+        if (absOverlap < response['overlap']) {
+          response['overlap'] = absOverlap;
+          response['overlapN'].copy(axis);
+          if (overlap < 0) response['overlapN'].reverse();
+        }
+      }
+
       T_VECTORS.push(offsetV);
       T_ARRAYS.push(rangeA);
       T_ARRAYS.push(rangeB);
+      return false;
+    },
+
+    /**
+     * ## Collision Tests
+     */
+
+    /**
+     * Check if a point is inside a circle.
+     * 
+     * @param {Vector} p The point to test.
+     * @param {Circle} c The circle to test.
+     * 
+     * @returns {boolean} Returns true if the point is inside the circle or false otherwise.
+     */
+    pointInCircle: function pointInCircle(p, c) {
+      var differenceV = T_VECTORS.pop().copy(p).sub(c['pos']).sub(c['offset']);
+      var radiusSq = c['r'] * c['r'];
+      var distanceSq = differenceV.len2();
+      T_VECTORS.push(differenceV); // If the distance between is smaller than the radius then the point is inside the circle.
+
+      return distanceSq <= radiusSq;
+    },
+
+    /**
+     * Check if a point is inside a convex polygon.
+     * 
+     * @param {Vector} p The point to test.
+     * @param {Polygon} poly The polygon to test.
+     * 
+     * @returns {boolean} Returns true if the point is inside the polygon or false otherwise.
+     */
+    pointInPolygon: function pointInPolygon(p, poly) {
+      TEST_POINT['pos'].copy(p);
+      T_RESPONSE.clear();
+      var result = this.testPolygonPolygon(TEST_POINT, poly, T_RESPONSE);
+      if (result) result = T_RESPONSE['aInB'];
+      return result;
+    },
+
+    /**
+     * Check if two circles collide.
+     * 
+     * @param {Circle} a The first circle.
+     * @param {Circle} b The second circle.
+     * @param {Response} [response] An optional response object that will be populated if the circles intersect.
+     * 
+     * @returns {boolean} Returns true if the circles intersect or false otherwise.
+     */
+    testCircleCircle: function testCircleCircle(a, b, response) {
+      // Check if the distance between the centers of the two circles is greater than their combined radius.
+      var differenceV = T_VECTORS.pop().copy(b['pos']).add(b['offset']).sub(a['pos']).sub(a['offset']);
+      var totalRadius = a['r'] + b['r'];
+      var totalRadiusSq = totalRadius * totalRadius;
+      var distanceSq = differenceV.len2(); // If the distance is bigger than the combined radius, they don't intersect.
+
+      if (distanceSq > totalRadiusSq) {
+        T_VECTORS.push(differenceV);
+        return false;
+      } // They intersect.  If we're calculating a response, calculate the overlap.
+
+
+      if (response) {
+        var dist = Math.sqrt(distanceSq);
+        response.a = a;
+        response.b = b;
+        response.overlap = totalRadius - dist;
+        response.overlapN.copy(differenceV.normalize());
+        response.overlapV.copy(differenceV).scale(response.overlap);
+        response.aInB = a.r <= b.r && dist <= b.r - a.r;
+        response.bInA = b.r <= a.r && dist <= a.r - b.r;
+      }
+
+      T_VECTORS.push(differenceV);
+      return true;
+    },
+
+    /**
+     * Check if a polygon and a circle collide.
+     * 
+     * @param {Polygon} polygon The polygon.
+     * @param {Circle} circle The circle.
+     * @param {Response} [response] An optional response object that will be populated if they intersect.
+     * 
+     * @returns {boolean} Returns true if they intersect or false otherwise.
+     */
+    testPolygonCircle: function testPolygonCircle(polygon, circle, response) {
+      // Get the position of the circle relative to the polygon.
+      var circlePos = T_VECTORS.pop().copy(circle.pos).add(circle.offset).sub(polygon.pos);
+      var radius = circle.r;
+      var radius2 = radius * radius;
+      var points = polygon.calcPoints;
+      var len = points.length;
+      var edge = T_VECTORS.pop();
+      var point = T_VECTORS.pop(); // For each edge in the polygon:
+
+      for (var i = 0; i < len; i++) {
+        var next = i === len - 1 ? 0 : i + 1;
+        var prev = i === 0 ? len - 1 : i - 1;
+        var overlap = 0;
+        var overlapN = null; // Get the edge.
+
+        edge.copy(polygon.edges[i]); // Calculate the center of the circle relative to the starting point of the edge.
+
+        point.copy(circlePos).sub(points[i]); // If the distance between the center of the circle and the point is bigger than the radius, the polygon is definitely not fully in the circle.
+
+        if (response && point.len2() > radius2) response.aInB = false; // Calculate which Voronoi region the center of the circle is in.
+
+        var region = voronoiRegion(edge, point); // If it's the left region:
+
+        if (region === LEFT_VORONOI_REGION) {
+          // We need to make sure we're in the RIGHT_VORONOI_REGION of the previous edge.
+          edge.copy(polygon.edges[prev]); // Calculate the center of the circle relative the starting point of the previous edge
+
+          var point2 = T_VECTORS.pop().copy(circlePos).sub(points[prev]);
+          region = voronoiRegion(edge, point2);
+
+          if (region === RIGHT_VORONOI_REGION) {
+            // It's in the region we want.  Check if the circle intersects the point.
+            var dist = point.len();
+
+            if (dist > radius) {
+              // No intersection
+              T_VECTORS.push(circlePos);
+              T_VECTORS.push(edge);
+              T_VECTORS.push(point);
+              T_VECTORS.push(point2);
+              return false;
+            } else if (response) {
+              // It intersects, calculate the overlap.
+              response.bInA = false;
+              overlapN = point.normalize();
+              overlap = radius - dist;
+            }
+          }
+
+          T_VECTORS.push(point2); // If it's the right region:
+        } else if (region === RIGHT_VORONOI_REGION) {
+          // We need to make sure we're in the left region on the next edge
+          edge.copy(polygon.edges[next]); // Calculate the center of the circle relative to the starting point of the next edge.
+
+          point.copy(circlePos).sub(points[next]);
+          region = voronoiRegion(edge, point);
+
+          if (region === LEFT_VORONOI_REGION) {
+            // It's in the region we want.  Check if the circle intersects the point.
+            var _dist = point.len();
+
+            if (_dist > radius) {
+              // No intersection
+              T_VECTORS.push(circlePos);
+              T_VECTORS.push(edge);
+              T_VECTORS.push(point);
+              return false;
+            } else if (response) {
+              // It intersects, calculate the overlap.
+              response.bInA = false;
+              overlapN = point.normalize();
+              overlap = radius - _dist;
+            }
+          } // Otherwise, it's the middle region:
+
+        } else {
+          // Need to check if the circle is intersecting the edge, change the edge into its "edge normal".
+          var normal = edge.perp().normalize(); // Find the perpendicular distance between the center of the circle and the edge.
+
+          var _dist2 = point.dot(normal);
+
+          var distAbs = Math.abs(_dist2); // If the circle is on the outside of the edge, there is no intersection.
+
+          if (_dist2 > 0 && distAbs > radius) {
+            // No intersection
+            T_VECTORS.push(circlePos);
+            T_VECTORS.push(normal);
+            T_VECTORS.push(point);
+            return false;
+          } else if (response) {
+            // It intersects, calculate the overlap.
+            overlapN = normal;
+            overlap = radius - _dist2; // If the center of the circle is on the outside of the edge, or part of the circle is on the outside, the circle is not fully inside the polygon.
+
+            if (_dist2 >= 0 || overlap < 2 * radius) response.bInA = false;
+          }
+        } // If this is the smallest overlap we've seen, keep it.
+        // (overlapN may be null if the circle was in the wrong Voronoi region).
+
+
+        if (overlapN && response && Math.abs(overlap) < Math.abs(response.overlap)) {
+          response.overlap = overlap;
+          response.overlapN.copy(overlapN);
+        }
+      } // Calculate the final overlap vector - based on the smallest overlap.
+
+
+      if (response) {
+        response.a = polygon;
+        response.b = circle;
+        response.overlapV.copy(response.overlapN).scale(response.overlap);
+      }
+
+      T_VECTORS.push(circlePos);
+      T_VECTORS.push(edge);
+      T_VECTORS.push(point);
+      return true;
+    },
+
+    /**
+     * Check if a circle and a polygon collide.
+     * 
+     * **NOTE:** This is slightly less efficient than polygonCircle as it just runs polygonCircle and reverses everything
+     * at the end.
+     * 
+     * @param {Circle} circle The circle.
+     * @param {Polygon} polygon The polygon.
+     * @param {Response} [response] An optional response object that will be populated if they intersect.
+     * 
+     * @returns {boolean} Returns true if they intersect or false otherwise.
+     */
+    testCirclePolygon: function testCirclePolygon(circle, polygon, response) {
+      // Test the polygon against the circle.
+      var result = testPolygonCircle(polygon, circle, response);
+
+      if (result && response) {
+        // Swap A and B in the response.
+        var a = response.a;
+        var aInB = response.aInB;
+        response.overlapN.reverse();
+        response.overlapV.reverse();
+        response.a = response.b;
+        response.b = a;
+        response.aInB = response.bInA;
+        response.bInA = aInB;
+      }
+
+      return result;
+    },
+
+    /**
+     * Checks whether polygons collide.
+     * 
+     * @param {Polygon} a The first polygon.
+     * @param {Polygon} b The second polygon.
+     * @param {Response} [response] An optional response object that will be populated if they intersect.
+     * 
+     * @returns {boolean} Returns true if they intersect or false otherwise.
+     */
+    testPolygonPolygon: function testPolygonPolygon(a, b, response) {
+      var aPoints = a.calcPoints;
+      var aLen = aPoints.length;
+      var bPoints = b.calcPoints;
+      var bLen = bPoints.length; // If any of the edge normals of A is a separating axis, no intersection.
+
+      for (var _i3 = 0; _i3 < aLen; _i3++) {
+        if (this.isSeparatingAxis(a.pos, b.pos, aPoints, bPoints, a.normals[_i3], response)) {
+          return false;
+        }
+      } // If any of the edge normals of B is a separating axis, no intersection.
+
+
+      for (var _i4 = 0; _i4 < bLen; _i4++) {
+        if (this.isSeparatingAxis(a.pos, b.pos, aPoints, bPoints, b.normals[_i4], response)) {
+          return false;
+        }
+      } // Since none of the edge normals of A or B are a separating axis, there is an intersection
+      // and we've already calculated the smallest overlap (in isSeparatingAxis). 
+      // Calculate the final overlap vector.
+
+
+      if (response) {
+        response['a'] = a;
+        response['b'] = b;
+        response['overlapV'].copy(response['overlapN']).scale(response['overlap']);
+      }
+
       return true;
     }
-    // This is not a separating axis. If we're calculating a response, calculate the overlap.
-    if (response) {
-      var overlap = 0;
-      // A starts further left than B
-      if (rangeA[0] < rangeB[0]) {
-        response['aInB'] = false;
-        // A ends before B does. We have to pull A out of B
-        if (rangeA[1] < rangeB[1]) {
-          overlap = rangeA[1] - rangeB[0];
-          response['bInA'] = false;
-        // B is fully inside A.  Pick the shortest way out.
-        } else {
-          var option1 = rangeA[1] - rangeB[0];
-          var option2 = rangeB[1] - rangeA[0];
-          overlap = option1 < option2 ? option1 : -option2;
-        }
-      // B starts further left than A
-      } else {
-        response['bInA'] = false;
-        // B ends before A ends. We have to push A out of B
-        if (rangeA[1] > rangeB[1]) {
-          overlap = rangeA[0] - rangeB[1];
-          response['aInB'] = false;
-        // A is fully inside B.  Pick the shortest way out.
-        } else {
-          var option1 = rangeA[1] - rangeB[0];
-          var option2 = rangeB[1] - rangeA[0];
-          overlap = option1 < option2 ? option1 : -option2;
-        }
-      }
-      // If this is the smallest amount of overlap we've seen so far, set it as the minimum overlap.
-      var absOverlap = Math.abs(overlap);
-      if (absOverlap < response['overlap']) {
-        response['overlap'] = absOverlap;
-        response['overlapN'].copy(axis);
-        if (overlap < 0) {
-          response['overlapN'].reverse();
-        }
-      }
-    }
-    T_VECTORS.push(offsetV);
-    T_ARRAYS.push(rangeA);
-    T_ARRAYS.push(rangeB);
-    return false;
-  }
-  SAT['isSeparatingAxis'] = isSeparatingAxis;
+  };
 
-  // Calculates which Voronoi region a point is on a line segment.
-  // It is assumed that both the line and the point are relative to `(0,0)`
-  //
-  //            |       (0)      |
-  //     (-1)  [S]--------------[E]  (1)
-  //            |       (0)      |
-  /**
-   * @param {Vector} line The line segment.
-   * @param {Vector} point The point.
-   * @return  {number} LEFT_VORONOI_REGION (-1) if it is the left region,
-   *          MIDDLE_VORONOI_REGION (0) if it is the middle region,
-   *          RIGHT_VORONOI_REGION (1) if it is the right region.
-   */
-  function voronoiRegion(line, point) {
-    var len2 = line.len2();
-    var dp = point.dot(line);
-    // If the point is beyond the start of the line, it is in the
-    // left voronoi region.
-    if (dp < 0) { return LEFT_VORONOI_REGION; }
-    // If the point is beyond the end of the line, it is in the
-    // right voronoi region.
-    else if (dp > len2) { return RIGHT_VORONOI_REGION; }
-    // Otherwise, it's in the middle one.
-    else { return MIDDLE_VORONOI_REGION; }
-  }
-  // Constants for Voronoi regions
-  /**
-   * @const
-   */
-  var LEFT_VORONOI_REGION = -1;
-  /**
-   * @const
-   */
-  var MIDDLE_VORONOI_REGION = 0;
-  /**
-   * @const
-   */
-  var RIGHT_VORONOI_REGION = 1;
+  return index;
 
-  // ## Collision Tests
-
-  // Check if a point is inside a circle.
-  /**
-   * @param {Vector} p The point to test.
-   * @param {Circle} c The circle to test.
-   * @return {boolean} true if the point is inside the circle, false if it is not.
-   */
-  function pointInCircle(p, c) {
-    var differenceV = T_VECTORS.pop().copy(p).sub(c['pos']).sub(c['offset']);
-    var radiusSq = c['r'] * c['r'];
-    var distanceSq = differenceV.len2();
-    T_VECTORS.push(differenceV);
-    // If the distance between is smaller than the radius then the point is inside the circle.
-    return distanceSq <= radiusSq;
-  }
-  SAT['pointInCircle'] = pointInCircle;
-
-  // Check if a point is inside a convex polygon.
-  /**
-   * @param {Vector} p The point to test.
-   * @param {Polygon} poly The polygon to test.
-   * @return {boolean} true if the point is inside the polygon, false if it is not.
-   */
-  function pointInPolygon(p, poly) {
-    TEST_POINT['pos'].copy(p);
-    T_RESPONSE.clear();
-    var result = testPolygonPolygon(TEST_POINT, poly, T_RESPONSE);
-    if (result) {
-      result = T_RESPONSE['aInB'];
-    }
-    return result;
-  }
-  SAT['pointInPolygon'] = pointInPolygon;
-
-  // Check if two circles collide.
-  /**
-   * @param {Circle} a The first circle.
-   * @param {Circle} b The second circle.
-   * @param {Response=} response Response object (optional) that will be populated if
-   *   the circles intersect.
-   * @return {boolean} true if the circles intersect, false if they don't.
-   */
-  function testCircleCircle(a, b, response) {
-    // Check if the distance between the centers of the two
-    // circles is greater than their combined radius.
-    var differenceV = T_VECTORS.pop().copy(b['pos']).add(b['offset']).sub(a['pos']).sub(a['offset']);
-    var totalRadius = a['r'] + b['r'];
-    var totalRadiusSq = totalRadius * totalRadius;
-    var distanceSq = differenceV.len2();
-    // If the distance is bigger than the combined radius, they don't intersect.
-    if (distanceSq > totalRadiusSq) {
-      T_VECTORS.push(differenceV);
-      return false;
-    }
-    // They intersect.  If we're calculating a response, calculate the overlap.
-    if (response) {
-      var dist = Math.sqrt(distanceSq);
-      response['a'] = a;
-      response['b'] = b;
-      response['overlap'] = totalRadius - dist;
-      response['overlapN'].copy(differenceV.normalize());
-      response['overlapV'].copy(differenceV).scale(response['overlap']);
-      response['aInB']= a['r'] <= b['r'] && dist <= b['r'] - a['r'];
-      response['bInA'] = b['r'] <= a['r'] && dist <= a['r'] - b['r'];
-    }
-    T_VECTORS.push(differenceV);
-    return true;
-  }
-  SAT['testCircleCircle'] = testCircleCircle;
-
-  // Check if a polygon and a circle collide.
-  /**
-   * @param {Polygon} polygon The polygon.
-   * @param {Circle} circle The circle.
-   * @param {Response=} response Response object (optional) that will be populated if
-   *   they interset.
-   * @return {boolean} true if they intersect, false if they don't.
-   */
-  function testPolygonCircle(polygon, circle, response) {
-    // Get the position of the circle relative to the polygon.
-    var circlePos = T_VECTORS.pop().copy(circle['pos']).add(circle['offset']).sub(polygon['pos']);
-    var radius = circle['r'];
-    var radius2 = radius * radius;
-    var points = polygon['calcPoints'];
-    var len = points.length;
-    var edge = T_VECTORS.pop();
-    var point = T_VECTORS.pop();
-
-    // For each edge in the polygon:
-    for (var i = 0; i < len; i++) {
-      var next = i === len - 1 ? 0 : i + 1;
-      var prev = i === 0 ? len - 1 : i - 1;
-      var overlap = 0;
-      var overlapN = null;
-
-      // Get the edge.
-      edge.copy(polygon['edges'][i]);
-      // Calculate the center of the circle relative to the starting point of the edge.
-      point.copy(circlePos).sub(points[i]);
-
-      // If the distance between the center of the circle and the point
-      // is bigger than the radius, the polygon is definitely not fully in
-      // the circle.
-      if (response && point.len2() > radius2) {
-        response['aInB'] = false;
-      }
-
-      // Calculate which Voronoi region the center of the circle is in.
-      var region = voronoiRegion(edge, point);
-      // If it's the left region:
-      if (region === LEFT_VORONOI_REGION) {
-        // We need to make sure we're in the RIGHT_VORONOI_REGION of the previous edge.
-        edge.copy(polygon['edges'][prev]);
-        // Calculate the center of the circle relative the starting point of the previous edge
-        var point2 = T_VECTORS.pop().copy(circlePos).sub(points[prev]);
-        region = voronoiRegion(edge, point2);
-        if (region === RIGHT_VORONOI_REGION) {
-          // It's in the region we want.  Check if the circle intersects the point.
-          var dist = point.len();
-          if (dist > radius) {
-            // No intersection
-            T_VECTORS.push(circlePos);
-            T_VECTORS.push(edge);
-            T_VECTORS.push(point);
-            T_VECTORS.push(point2);
-            return false;
-          } else if (response) {
-            // It intersects, calculate the overlap.
-            response['bInA'] = false;
-            overlapN = point.normalize();
-            overlap = radius - dist;
-          }
-        }
-        T_VECTORS.push(point2);
-      // If it's the right region:
-      } else if (region === RIGHT_VORONOI_REGION) {
-        // We need to make sure we're in the left region on the next edge
-        edge.copy(polygon['edges'][next]);
-        // Calculate the center of the circle relative to the starting point of the next edge.
-        point.copy(circlePos).sub(points[next]);
-        region = voronoiRegion(edge, point);
-        if (region === LEFT_VORONOI_REGION) {
-          // It's in the region we want.  Check if the circle intersects the point.
-          var dist = point.len();
-          if (dist > radius) {
-            // No intersection
-            T_VECTORS.push(circlePos);
-            T_VECTORS.push(edge);
-            T_VECTORS.push(point);
-            return false;
-          } else if (response) {
-            // It intersects, calculate the overlap.
-            response['bInA'] = false;
-            overlapN = point.normalize();
-            overlap = radius - dist;
-          }
-        }
-      // Otherwise, it's the middle region:
-      } else {
-        // Need to check if the circle is intersecting the edge,
-        // Change the edge into its "edge normal".
-        var normal = edge.perp().normalize();
-        // Find the perpendicular distance between the center of the
-        // circle and the edge.
-        var dist = point.dot(normal);
-        var distAbs = Math.abs(dist);
-        // If the circle is on the outside of the edge, there is no intersection.
-        if (dist > 0 && distAbs > radius) {
-          // No intersection
-          T_VECTORS.push(circlePos);
-          T_VECTORS.push(normal);
-          T_VECTORS.push(point);
-          return false;
-        } else if (response) {
-          // It intersects, calculate the overlap.
-          overlapN = normal;
-          overlap = radius - dist;
-          // If the center of the circle is on the outside of the edge, or part of the
-          // circle is on the outside, the circle is not fully inside the polygon.
-          if (dist >= 0 || overlap < 2 * radius) {
-            response['bInA'] = false;
-          }
-        }
-      }
-
-      // If this is the smallest overlap we've seen, keep it.
-      // (overlapN may be null if the circle was in the wrong Voronoi region).
-      if (overlapN && response && Math.abs(overlap) < Math.abs(response['overlap'])) {
-        response['overlap'] = overlap;
-        response['overlapN'].copy(overlapN);
-      }
-    }
-
-    // Calculate the final overlap vector - based on the smallest overlap.
-    if (response) {
-      response['a'] = polygon;
-      response['b'] = circle;
-      response['overlapV'].copy(response['overlapN']).scale(response['overlap']);
-    }
-    T_VECTORS.push(circlePos);
-    T_VECTORS.push(edge);
-    T_VECTORS.push(point);
-    return true;
-  }
-  SAT['testPolygonCircle'] = testPolygonCircle;
-
-  // Check if a circle and a polygon collide.
-  //
-  // **NOTE:** This is slightly less efficient than polygonCircle as it just
-  // runs polygonCircle and reverses everything at the end.
-  /**
-   * @param {Circle} circle The circle.
-   * @param {Polygon} polygon The polygon.
-   * @param {Response=} response Response object (optional) that will be populated if
-   *   they interset.
-   * @return {boolean} true if they intersect, false if they don't.
-   */
-  function testCirclePolygon(circle, polygon, response) {
-    // Test the polygon against the circle.
-    var result = testPolygonCircle(polygon, circle, response);
-    if (result && response) {
-      // Swap A and B in the response.
-      var a = response['a'];
-      var aInB = response['aInB'];
-      response['overlapN'].reverse();
-      response['overlapV'].reverse();
-      response['a'] = response['b'];
-      response['b'] = a;
-      response['aInB'] = response['bInA'];
-      response['bInA'] = aInB;
-    }
-    return result;
-  }
-  SAT['testCirclePolygon'] = testCirclePolygon;
-
-  // Checks whether polygons collide.
-  /**
-   * @param {Polygon} a The first polygon.
-   * @param {Polygon} b The second polygon.
-   * @param {Response=} response Response object (optional) that will be populated if
-   *   they interset.
-   * @return {boolean} true if they intersect, false if they don't.
-   */
-  function testPolygonPolygon(a, b, response) {
-    var aPoints = a['calcPoints'];
-    var aLen = aPoints.length;
-    var bPoints = b['calcPoints'];
-    var bLen = bPoints.length;
-    // If any of the edge normals of A is a separating axis, no intersection.
-    for (var i = 0; i < aLen; i++) {
-      if (isSeparatingAxis(a['pos'], b['pos'], aPoints, bPoints, a['normals'][i], response)) {
-        return false;
-      }
-    }
-    // If any of the edge normals of B is a separating axis, no intersection.
-    for (var i = 0;i < bLen; i++) {
-      if (isSeparatingAxis(a['pos'], b['pos'], aPoints, bPoints, b['normals'][i], response)) {
-        return false;
-      }
-    }
-    // Since none of the edge normals of A or B are a separating axis, there is an intersection
-    // and we've already calculated the smallest overlap (in isSeparatingAxis).  Calculate the
-    // final overlap vector.
-    if (response) {
-      response['a'] = a;
-      response['b'] = b;
-      response['overlapV'].copy(response['overlapN']).scale(response['overlap']);
-    }
-    return true;
-  }
-  SAT['testPolygonPolygon'] = testPolygonPolygon;
-
-  return SAT;
-}));
+})));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sat",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1412 @@
+{
+  "name": "sat",
+  "version": "0.8.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/core": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.7.tgz",
+      "integrity": "sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.7.7",
+        "@babel/helpers": "^7.7.4",
+        "@babel/parser": "^7.7.7",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+      "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.7.4",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
+      "integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
+      "integrity": "sha512-Biq/d/WtvfftWZ9Uf39hbPBYDUo986m5Bb4zhkeYDGUllF43D+nUe5M6Vuo6/8JDK/0YX/uBdeoQpyaNhNugZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.7.4",
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
+      "integrity": "sha512-8JH9/B7J7tCYJ2PpWVpw9JhPuEVHztagNVuQAFBVFYluRMlpG7F1CgKEgGeL6KFqcsIa92ZYVj6DSc0XwmN1ZA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
+      "integrity": "sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.6.0"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
+      "integrity": "sha512-v5LorqOa0nVQUvAUTUF3KPastvUt/HzByXNamKQ6RdJRTV7j8rLL+WB5C/MzzWAwOomxDhYFb1wLLxHqox86lg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/types": "^7.7.4",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
+      "integrity": "sha512-2/SicuFrNSXsZNBxe5UGdLr+HZg+raWBLE9vC98bdYOKX/U6PY0mdGlYUJdtTDPSU0Lw0PNbKKDpwYHJLn2jLg==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+      "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.7.4",
+        "@babel/template": "^7.7.4",
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+      "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
+      "integrity": "sha512-wQC4xyvc1Jo/FnLirL6CEgPgPCa8M74tOdjWpRhQYapz5JC7u3NYU1zCVoVAGCE3EaIP9T1A3iW0WLJ+reZlpQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
+      "integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
+      "integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
+      "integrity": "sha512-A7pSxyJf1gN5qXVcidwLWydjftUN878VkalhXX5iQDuGyiGK3sOrrKKHF4/A4fwHtnsotv/NipwAeLzY4KQPvw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.7.4",
+        "@babel/helper-simple-access": "^7.7.4",
+        "@babel/helper-split-export-declaration": "^7.7.4",
+        "@babel/template": "^7.7.4",
+        "@babel/types": "^7.7.4",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
+      "integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+      "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
+      "integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.7.4",
+        "@babel/helper-wrap-function": "^7.7.4",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
+      "integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.7.4",
+        "@babel/helper-optimise-call-expression": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
+      "integrity": "sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.7.4",
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+      "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
+      "integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
+      "integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+      "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
+      "integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.7.4",
+        "@babel/plugin-syntax-async-generators": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
+      "integrity": "sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
+      "integrity": "sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-json-strings": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.7.tgz",
+      "integrity": "sha512-3qp9I8lelgzNedI3hrhkvhaEYree6+WHnyA/q4Dza9z7iEIs1eyhWyJnetk3jJ69RT0AT4G0UhEGwyGFJ7GUuQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
+      "integrity": "sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.7.tgz",
+      "integrity": "sha512-80PbkKyORBUVm1fbTLrHpYdJxMThzM1UqFGh0ALEhO9TYbG86Ah9zQYAB/84axz2vcxefDLdZwWwZNlYARlu9w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
+      "integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
+      "integrity": "sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
+      "integrity": "sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
+      "integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
+      "integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz",
+      "integrity": "sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
+      "integrity": "sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
+      "integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.7.4"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
+      "integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
+      "integrity": "sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
+      "integrity": "sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.7.4",
+        "@babel/helper-define-map": "^7.7.4",
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/helper-optimise-call-expression": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.7.4",
+        "@babel/helper-split-export-declaration": "^7.7.4",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
+      "integrity": "sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
+      "integrity": "sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.7.tgz",
+      "integrity": "sha512-b4in+YlTeE/QmTgrllnb3bHA0HntYvjz8O3Mcbx75UBPJA2xhb5A8nle498VhxSXJHQefjtQxpnLPehDJ4TRlg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
+      "integrity": "sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
+      "integrity": "sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
+      "integrity": "sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
+      "integrity": "sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
+      "integrity": "sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
+      "integrity": "sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
+      "integrity": "sha512-CT57FG4A2ZUNU1v+HdvDSDrjNWBrtCmSH6YbbgN3Lrf0Di/q/lWRxZrE72p3+HCCz9UjfZOEBdphgC0nzOS6DQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.7.5",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
+      "integrity": "sha512-9Cq4zTFExwFhQI6MT1aFxgqhIsMWQWDVwOgLzl7PTWJHsNaqFvklAU+Oz6AQLAS0dJKTwZSOCo20INwktxpi3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.7.5",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-simple-access": "^7.7.4",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
+      "integrity": "sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
+      "integrity": "sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
+      "integrity": "sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.7.4"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
+      "integrity": "sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
+      "integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.7.4"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.7.tgz",
+      "integrity": "sha512-OhGSrf9ZBrr1fw84oFXj5hgi8Nmg+E2w5L7NhnG0lPvpDtqd7dbyilM2/vR8CKbJ907RyxPh2kj6sBCSSfI9Ew==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "^7.7.4",
+        "@babel/helper-get-function-arity": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
+      "integrity": "sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.5.tgz",
+      "integrity": "sha512-/8I8tPvX2FkuEyWbjRCt4qTAgZK0DVy8QRguhA524UH48RfGJy94On2ri+dCuwOpcerPRl9O4ebQkRcVzIaGBw==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.14.0"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz",
+      "integrity": "sha512-OrPiUB5s5XvkCO1lS7D8ZtHcswIC57j62acAnJZKqGGnHP+TIc/ljQSrgdX/QyOTdEK5COAhuc820Hi1q2UgLQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
+      "integrity": "sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
+      "integrity": "sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
+      "integrity": "sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
+      "integrity": "sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
+      "integrity": "sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
+      "integrity": "sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.7.tgz",
+      "integrity": "sha512-pCu0hrSSDVI7kCVUOdcMNQEbOPJ52E+LrQ14sN8uL2ALfSqePZQlKrOy+tM4uhEdYlCHi4imr8Zz2cZe9oSdIg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.7.4",
+        "@babel/plugin-proposal-dynamic-import": "^7.7.4",
+        "@babel/plugin-proposal-json-strings": "^7.7.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.7.7",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.7.7",
+        "@babel/plugin-syntax-async-generators": "^7.7.4",
+        "@babel/plugin-syntax-dynamic-import": "^7.7.4",
+        "@babel/plugin-syntax-json-strings": "^7.7.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.7.4",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
+        "@babel/plugin-syntax-top-level-await": "^7.7.4",
+        "@babel/plugin-transform-arrow-functions": "^7.7.4",
+        "@babel/plugin-transform-async-to-generator": "^7.7.4",
+        "@babel/plugin-transform-block-scoped-functions": "^7.7.4",
+        "@babel/plugin-transform-block-scoping": "^7.7.4",
+        "@babel/plugin-transform-classes": "^7.7.4",
+        "@babel/plugin-transform-computed-properties": "^7.7.4",
+        "@babel/plugin-transform-destructuring": "^7.7.4",
+        "@babel/plugin-transform-dotall-regex": "^7.7.7",
+        "@babel/plugin-transform-duplicate-keys": "^7.7.4",
+        "@babel/plugin-transform-exponentiation-operator": "^7.7.4",
+        "@babel/plugin-transform-for-of": "^7.7.4",
+        "@babel/plugin-transform-function-name": "^7.7.4",
+        "@babel/plugin-transform-literals": "^7.7.4",
+        "@babel/plugin-transform-member-expression-literals": "^7.7.4",
+        "@babel/plugin-transform-modules-amd": "^7.7.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.7.5",
+        "@babel/plugin-transform-modules-systemjs": "^7.7.4",
+        "@babel/plugin-transform-modules-umd": "^7.7.4",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
+        "@babel/plugin-transform-new-target": "^7.7.4",
+        "@babel/plugin-transform-object-super": "^7.7.4",
+        "@babel/plugin-transform-parameters": "^7.7.7",
+        "@babel/plugin-transform-property-literals": "^7.7.4",
+        "@babel/plugin-transform-regenerator": "^7.7.5",
+        "@babel/plugin-transform-reserved-words": "^7.7.4",
+        "@babel/plugin-transform-shorthand-properties": "^7.7.4",
+        "@babel/plugin-transform-spread": "^7.7.4",
+        "@babel/plugin-transform-sticky-regex": "^7.7.4",
+        "@babel/plugin-transform-template-literals": "^7.7.4",
+        "@babel/plugin-transform-typeof-symbol": "^7.7.4",
+        "@babel/plugin-transform-unicode-regex": "^7.7.4",
+        "@babel/types": "^7.7.4",
+        "browserslist": "^4.6.0",
+        "core-js-compat": "^3.6.0",
+        "invariant": "^2.2.2",
+        "js-levenshtein": "^1.1.3",
+        "semver": "^5.5.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+      "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.4",
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+      "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.7.4",
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/helper-split-export-declaration": "^7.7.4",
+        "@babel/parser": "^7.7.4",
+        "@babel/types": "^7.7.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+      "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.41.tgz",
+      "integrity": "sha512-rIAmXyJlqw4KEBO7+u9gxZZSQHaCNnIzYrnNmYVpgfJhxTqO0brCX0SYpqUTkVI5mwwUwzmtspLBGBKroMeynA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.1.tgz",
+      "integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
+    "browserslist": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+      "integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001015",
+        "electron-to-chromium": "^1.3.322",
+        "node-releases": "^1.1.42"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001017",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001017.tgz",
+      "integrity": "sha512-EDnZyOJ6eYh6lHmCvCdHAFbfV4KJ9lSdfv4h/ppEhrU/Yudkl7jujwMZ1we6RX7DXqBfT04pVMQ4J+1wcTlsKA==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "core-js-compat": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.1.tgz",
+      "integrity": "sha512-2Tl1EuxZo94QS2VeH28Ebf5g3xbPZG/hj/N5HDDy4XMP/ImR0JIer/nggQRiMN91Q54JVkGbytf42wO29oXVHg==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.8.2",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.322",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+      "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.44.tgz",
+      "integrity": "sha512-NwbdvJyR7nrcGrXvKAvzc5raj/NkoJudkarh2yIpJ4t0NH4aqjUDz/486P+ynIW5eokKOfzGNRdYoLfBlomruw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
+    "regenerator-transform": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+      "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+      "dev": true,
+      "requires": {
+        "private": "^0.1.6"
+      }
+    },
+    "regexpu-core": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+      "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.1.0",
+        "regjsgen": "^0.5.0",
+        "regjsparser": "^0.6.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.1.0"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+      "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
+      "integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "resolve": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
+      "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "rollup": {
+      "version": "1.27.14",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.14.tgz",
+      "integrity": "sha512-DuDjEyn8Y79ALYXMt+nH/EI58L5pEw5HU9K38xXdRnxQhvzUTI/nxAawhkAHUQeudANQ//8iyrhVRHJBuR6DSQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      }
+    },
+    "rollup-plugin-babel": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.3.tgz",
+      "integrity": "sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,10 +17,16 @@
     "url": "http://github.com/jriecken/sat-js/issues"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "bundle": "rollup -c",
+    "bundle:watch": "rollup -c --watch"
   },
   "main": "SAT.js",
   "devDependencies": {
-    "mocha": "^2.1.0"
+    "@babel/core": "^7.7.7",
+    "@babel/preset-env": "^7.7.7",
+    "mocha": "^2.1.0",
+    "rollup": "^1.27.14",
+    "rollup-plugin-babel": "^4.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sat",
   "description": "Library for performing 2D collision detection",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": "Jim Riecken <jriecken@gmail.com>",
   "keywords": [
     "collision detection",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,29 @@
+'use strict'
+
+import pkg from './package.json';
+import babel from 'rollup-plugin-babel';
+
+export default {
+  /**
+   * Specify the input file.
+   */
+  input: 'src/index.js',
+
+  /**
+   * We use babel to transpile the es6 to es5 for the greatest browser support.
+   */
+  plugins: [
+    babel()
+  ],
+
+  /**
+   * Create just a umd build that can be used on both Node and the browser.
+   */
+  output: [
+    {
+      name: 'SAT',
+      file: pkg.main,
+      format: 'umd'
+    }
+  ],
+};

--- a/src/Box.js
+++ b/src/Box.js
@@ -1,0 +1,43 @@
+'use strict'
+
+import Vector from './Vector';
+import Polygon from './Polygon';
+
+/**
+ * ## Box
+ * 
+ * Represents an axis-aligned box, with a width and height.
+ */
+export default class Box {
+  /**
+   * Creates a new Box, with the specified position, width, and height.
+   * 
+   * If no position is given, the position will be `(0, 0)`. If no width or height are given, they will
+   * be set to `0`.
+   * 
+   * @param {Vector} [pos=new Vector()] A Vector representing the bottom-left of the box(i.e. the smallest x and smallest y value).
+   * @param {number} [w=0] The width of the Box.
+   * @param {number} [h=0] The height of the Box.
+   */
+  constructor(pos = new Vector(), w = 0, h = 0) {
+    this.pos = pos;
+    this.w = w;
+    this.h = h;
+  }
+
+  /**
+   * Returns a Polygon whose edges are the same as this Box.
+   * 
+   * @returns {Polygon} A new Polygon that represents this Box.
+   */
+  toPolygon() {
+    const pos = this.pos;
+    const w = this.w;
+    const h = this.h;
+
+    return new Polygon(new Vector(pos.x, pos.y), [
+      new Vector(), new Vector(w, 0),
+      new Vector(w, h), new Vector(0, h)
+    ]);
+  }
+}

--- a/src/Circle.js
+++ b/src/Circle.js
@@ -1,0 +1,52 @@
+'use strict'
+
+import Vector from './Vector';
+
+/**
+ * ## Circle
+ * 
+ * Represents a circle with a position and a radius.
+ * 
+ * Creates a new Circle, optionally passing in a position and/or radius. If no position
+ * is given, the Circle will be at `(0,0)`. If no radius is provided the circle will have
+ * a radius of `0`.
+ */
+export default class Circle {
+  /**
+   * @param {Vector} pos A Vector representing the center of this Circle.
+   * @param {number} r The radius of this Circle. 
+   */
+  constructor(pos = new Vector(), r = 0) {
+    this.pos = pos;
+    this.r = r;
+    this.offset = new Vector();
+  }
+
+  /**
+   * Compute the axis-aligned bounding box (AABB) of this Circle.
+   * 
+   * Note: Returns a _new_ `Polygon` each time you call this.
+   * 
+   * @returns {Polygon} Returns the AABB.
+   */
+  getAABB() {
+    const r = this.r;
+
+    const corner = this.pos.clone().add(this.offset).sub(new Vector(r, r));
+
+    return new Box(corner, r * 2, r * 2).toPolygon();
+  }
+
+  /**
+   * Set the current offset to apply to the radius.
+   * 
+   * @param {Vector} offset The new offset Vector.
+   * 
+   * @returns {Circle} Returns this for chaining.
+   */
+  setOffset(offset) {
+    this.offset = offset;
+
+    return this;
+  }
+}

--- a/src/Polygon.js
+++ b/src/Polygon.js
@@ -1,0 +1,275 @@
+'use strict'
+
+import Vector from './Vector';
+
+/**
+ * ## Polygon
+ * 
+ * Represents a *convex* polygon with any number of points (specified in counter-clockwise order).
+ * 
+ * Note: Do _not_ manually change the `points`, `angle`, or `offset` properties. Use the provided 
+ * setters. Otherwise the calculated properties will not be updated correctly.
+ * 
+ * `pos` can be changed directly.
+ */
+export default class Polygon {
+  /**
+   * Create a new polygon, passing in a position vector, and an array of points (represented by vectors 
+   * relative to the position vector). If no position is passed in, the position of the polygon will be `(0,0)`.
+   * 
+   * @param {Vector} [pos=Vector] A vector representing the origin of the polygon (all other points are relative to this one)
+   * @param {Array<Vector>} [points=[]] An array of vectors representing the points in the polygon, in counter-clockwise order.
+   */
+  constructor(pos = new Vector(), points = []) {
+    this.pos = pos;
+    this.angle = 0;
+    this.offset = new Vector();
+
+    this.setPoints(points);
+  }
+
+  /**
+   * Set the points of the polygon. Any consecutive duplicate points will be combined.
+   * 
+   * Note: The points are counter-clockwise *with respect to the coordinate system*. If you directly draw the points on a screen 
+   * that has the origin at the top-left corner it will _appear_ visually that the points are being specified clockwise. This is 
+   * just because of the inversion of the Y-axis when being displayed.
+   * 
+   * @param {Array<Vector>} points An array of vectors representing the points in the polygon, in counter-clockwise order.
+   * 
+   * @returns {Polygon} Returns this for chaining.
+   */
+  setPoints(points) {
+    // Only re-allocate if this is a new polygon or the number of points has changed.
+    const lengthChanged = !this.points || this.points.length !== points.length;
+
+    if (lengthChanged) {
+      let i;
+
+      const calcPoints = this.calcPoints = [];
+      const edges = this.edges = [];
+      const normals = this.normals = [];
+
+      // Allocate the vector arrays for the calculated properties
+      for (i = 0; i < points.length; i++) {
+        // Remove consecutive duplicate points
+        const p1 = points[i];
+        const p2 = i < points.length - 1 ? points[i + 1] : points[0];
+
+        if (p1 !== p2 && p1.x === p2.x && p1.y === p2.y) {
+          points.splice(i, 1);
+          i -= 1;
+          continue;
+        }
+
+        calcPoints.push(new Vector());
+        edges.push(new Vector());
+        normals.push(new Vector());
+      }
+    }
+
+    this.points = points;
+
+    this._recalc();
+
+    return this;
+  }
+
+  /**
+   * Set the current rotation angle of the polygon.
+   * 
+   * @param {number} angle The current rotation angle (in radians).
+   * 
+   * @returns {Polygon} Returns this for chaining.
+   */
+  setAngle(angle) {
+    this.angle = angle;
+
+    this._recalc();
+
+    return this;
+  }
+
+  /**
+   * Set the current offset to apply to the `points` before applying the `angle` rotation.
+   * 
+   * @param {Vector} offset The new offset Vector.
+   * 
+   * @returns {Polygon} Returns this for chaining.
+   */
+  setOffset(offset) {
+    this.offset = offset;
+
+    this._recalc();
+
+    return this;
+  }
+
+  /**
+   * Rotates this Polygon counter-clockwise around the origin of *its local coordinate system* (i.e. `pos`).
+   * 
+   * Note: This changes the **original** points (so any `angle` will be applied on top of this rotation).
+   * 
+   * @param {number} angle The angle to rotate (in radians).
+   * 
+   * @returns {Polygon} Returns this for chaining.
+   */
+  rotate(angle) {
+    const points = this.points;
+    const len = points.length;
+
+    for (let i = 0; i < len; i++) points[i].rotate(angle);
+
+    this._recalc();
+
+    return this;
+  }
+
+  /**
+   * Translates the points of this polygon by a specified amount relative to the origin of *its own coordinate system* (i.e. `pos`).
+   * 
+   * Note: This changes the **original** points (so any `offset` will be applied on top of this translation)
+   * 
+   * @param {number} x The horizontal amount to translate.
+   * @param {number} y The vertical amount to translate.
+   * 
+   * @returns {Polygon} Returns this for chaining.
+   */
+  translate(x, y) {
+    const points = this.points;
+    const len = points.length;
+
+    for (let i = 0; i < len; i++) {
+      points[i].x += x;
+      points[i].y += y;
+    }
+
+    this._recalc();
+
+    return this;
+  }
+
+  /**
+   * Computes the calculated collision Polygon.
+   * 
+   * This applies the `angle` and `offset` to the original points then recalculates the edges and normals of the collision Polygon.
+   * 
+   * @private
+   * 
+   * @returns {Polygon} Returns this for chaining.
+   */
+  _recalc() {
+    // Calculated points - this is what is used for underlying collisions and takes into account
+    // the angle/offset set on the polygon.
+    const calcPoints = this.calcPoints;
+
+    // The edges here are the direction of the `n`th edge of the polygon, relative to
+    // the `n`th point. If you want to draw a given edge from the edge value, you must
+    // first translate to the position of the starting point.
+    const edges = this.edges;
+
+    // The normals here are the direction of the normal for the `n`th edge of the polygon, relative
+    // to the position of the `n`th point. If you want to draw an edge normal, you must first
+    // translate to the position of the starting point.
+    const normals = this.normals;
+
+    // Copy the original points array and apply the offset/angle
+    const points = this.points;
+    const offset = this.offset;
+    const angle = this.angle;
+
+    const len = points.length;
+    let i;
+
+    for (i = 0; i < len; i++) {
+      const calcPoint = calcPoints[i].copy(points[i]);
+
+      calcPoint.x += offset.x;
+      calcPoint.y += offset.y;
+
+      if (angle !== 0) calcPoint.rotate(angle);
+    }
+
+    // Calculate the edges/normals
+    for (i = 0; i < len; i++) {
+      const p1 = calcPoints[i];
+      const p2 = i < len - 1 ? calcPoints[i + 1] : calcPoints[0];
+
+      const e = edges[i].copy(p2).sub(p1);
+
+      normals[i].copy(e).perp().normalize();
+    }
+
+    return this;
+  }
+
+  /**
+   * Compute the axis-aligned bounding box.
+   * 
+   * Any current state (translations/rotations) will be applied before constructing the AABB.
+   * 
+   * Note: Returns a _new_ `Polygon` each time you call this.
+   * 
+   * @returns {Polygon} Returns this for chaining.
+   */
+  getAABB() {
+    const points = this.calcPoints;
+    const len = points.length;
+
+    const xMin = points[0].x;
+    const yMin = points[0].y;
+
+    const xMax = points[0].x;
+    const yMax = points[0].y;
+
+    for (let i = 1; i < len; i++) {
+      const point = points[i];
+
+      if (point["x"] < xMin) xMin = point["x"];
+      else if (point["x"] > xMax) xMax = point["x"];
+
+      if (point["y"] < yMin) yMin = point["y"];
+      else if (point["y"] > yMax) yMax = point["y"];
+
+    }
+
+    return new Box(this['pos'].clone().add(new Vector(xMin, yMin)), xMax - xMin, yMax - yMin).toPolygon();
+  }
+
+  /**
+   * Compute the centroid (geometric center) of the Polygon.
+   * 
+   * Any current state (translations/rotations) will be applied before computing the centroid.
+   * 
+   * See https://en.wikipedia.org/wiki/Centroid#Centroid_of_a_polygon
+   * 
+   * Note: Returns a _new_ `Vector` each time you call this.
+   * 
+   * @returns {Vector} Returns a Vector that contains the coordinates of the centroid.
+   */
+  getCentroid() {
+    const points = this.calcPoints;
+    const len = points.length;
+
+    let cx = 0;
+    let cy = 0;
+    let ar = 0;
+
+    for (var i = 0; i < len; i++) {
+      const p1 = points[i];
+      const p2 = i === len - 1 ? points[0] : points[i + 1]; // Loop around if last point
+
+      const a = p1["x"] * p2["y"] - p2["x"] * p1["y"];
+
+      cx += (p1["x"] + p2["x"]) * a;
+      cy += (p1["y"] + p2["y"]) * a;
+      ar += a;
+    }
+
+    ar = ar * 3; // we want 1 / 6 the area and we currently have 2*area
+    cx = cx / ar;
+    cy = cy / ar;
+    
+    return new Vector(cx, cy);
+  }
+}

--- a/src/Response.js
+++ b/src/Response.js
@@ -1,0 +1,41 @@
+'use strict'
+
+import Vector from './Vector';
+
+/**
+ * ## Response
+ * 
+ * An object representing the result of an intersection. Contains:
+ * - The two objects participating in the intersection
+ * - The vector representing the minimum change necessary to extract the first object from the second one (as well as a unit vector in that direction and the magnitude of the overlap)
+ * - Whether the first object is entirely inside the second, and vice versa.
+ */
+export default class Response {
+  constructor() {
+    this.a = null;
+    this.b = null;
+
+    this.overlapN = new Vector();
+    this.overlapV = new Vector();
+
+    this.clear();
+  }
+
+  /**
+   * Set some values of the response back to their defaults.
+   * 
+   * Call this between tests if you are going to reuse a single Response object for multiple intersection tests (recommended as it will avoid allcating extra memory)
+   * 
+   * @returns {Response} Returns this for chaining.
+   */
+  clear() {
+    this.aInB = true;
+    this.bInA = true;
+
+    this.overlap = Number.MAX_VALUE;
+
+    return this;
+  }
+
+  
+}

--- a/src/Vector.js
+++ b/src/Vector.js
@@ -1,0 +1,253 @@
+'use strict'
+
+/**
+ * ## Vector
+ * 
+ * Represents a vector in two dimensions with `x` and `y` properties.
+ * 
+ * Create a new Vector, optionally passing in the `x` and `y` coordinates. If a coordinate is not specified, 
+ * it will be set to `0`.
+ */
+export default class Vector {
+  /**
+   * @param {number} [x=0] The x coordinate of this Vector.
+   * @param {number} [y=0] The y coordinate of this Vector.
+   */
+  constructor(x = 0, y = 0) {
+    this.x = x;
+    this.y = y;
+  }
+
+  /**
+   * Copy the values of another Vector into this one.
+   * 
+   * @param {*} other The other Vector.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  copy(other) {
+    this.x = other.x;
+    this.y = other.y;
+
+    return this;
+  }
+
+  /**
+   * Create a new Vector with the same coordinates as the one.
+   * 
+   * @returns {Vector} The new cloned Vector.
+   */
+  clone() {
+    return new Vector(this.x, this.y);
+  }
+
+  /**
+   * Change this Vector to be perpendicular to what it was before.
+   * 
+   * Effectively this rotates it 90 degrees in a clockwise direction.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  perp() {
+    const x = this.x;
+
+    this.x = this.y;
+    this.y = -x;
+
+    return this;
+  }
+
+  /**
+   * Rotate this Vector (counter-clockwise) by the specified angle (in radians).
+   * 
+   * @param {number} angle The angle to rotate (in radians).
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  rotate(angle) {
+    const x = this.x;
+    const y = this.y;
+
+    this.x = x * Math.cos(angle) - y * Math.sin(angle);
+    this.y = x * Math.sin(angle) + y * Math.cos(angle);
+
+    return this;
+  }
+
+  /**
+   * Reverse this Vector.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  reverse() {
+    this.x = -this.x;
+    this.y = -this.y;
+
+    return this;
+  }
+
+  /**
+   * Normalize this vector (make it have a length of `1`).
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  normalize() {
+    const d = this.len();
+
+    if (d > 0) {
+      this.x = this.x / d;
+      this.y = this.y / d;
+    }
+
+    return this;
+  }
+
+  /**
+   * Add another Vector to this one.
+   * 
+   * @param {Vector} other The other Vector.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  add(other) {
+    this.x += other.x;
+    this.y += other.y;
+
+    return this;
+  }
+
+  /**
+   * Subtract another Vector from this one.
+   * 
+   * @param {Vector} other The other Vector.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  sub(other) {
+    this.x -= other.x;
+    this.y -= other.y;
+
+    return this;
+  }
+
+  /**
+   * Scale this Vector.
+   * 
+   * An independent scaling factor can be provided for each axis, or a single scaling factor will scale
+   * both `x` and `y`.
+   * 
+   * @param {number} x The scaling factor in the x direction.
+   * @param {number} [y] The scaling factor in the y direction.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  scale(x, y) {
+    this.x *= x;
+    this.y *= typeof y != 'undefined' ? y : x;
+
+    return this;
+  }
+
+  /**
+   * Project this Vector onto another Vector.
+   * 
+   * @param {Vector} other The Vector to project onto.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  project(other) {
+    const amt = this.dot(other) / other.len2();
+
+    this.x = amt * other.x;
+    this.y = amt * other.y;
+
+    return this;
+  }
+
+  /**
+   * Project this Vector onto a Vector of unit length.
+   * 
+   * This is slightly more efficient than `project` when dealing with unit vectors.
+   * 
+   * @param {Vector} other The unit vector to project onto.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  projectN(other) {
+    const amt = this.dot(other);
+
+    this.x = amt * other.x;
+    this.y = amt * other.y;
+
+    return this;
+  }
+
+  /**
+   * Reflect this Vector on an arbitrary axis.
+   * 
+   * @param {Vector} axis The Vector representing the axis.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  reflect(axis) {
+    const x = this.x;
+    const y = this.y;
+
+    this.project(axis).scale(2);
+
+    this.x -= x;
+    this.y -= y;
+
+    return this;
+  }
+
+  /**
+   * Reflect this Vector on an arbitrary axis.
+   * 
+   * This is slightly more efficient than `reflect` when dealing with an axis that is a unit vector.
+   * 
+   * @param {Vector} axis The Vector representing the axis.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  reflectN(axis) {
+    const x = this.x;
+    const y = this.y;
+
+    this.projectN(axis).scale(2);
+
+    this.x -= x;
+    this.y -= y;
+
+    return this;
+  }
+
+  /**
+   * Get the dot product of this Vector and another.
+   * 
+   * @param {Vector} other The Vector to dot this one against.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  dot(other) {
+    return this.x * other.x + this.y * other.y;
+  }
+
+  /**
+   * Get the squared length of this Vector.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  len2() {
+    return this.dot(this);
+  }
+
+  /**
+   * Get the length of this Vector.
+   * 
+   * @returns {Vector} Returns this for chaining.
+   */
+  len() {
+    return Math.sqrt(this.len2());
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,528 @@
+'use strict'
+
+import Box from './Box';
+import Vector from './Vector';
+import Circle from './Circle';
+import Polygon from './Polygon';
+import Response from './Response';
+
+/**
+ * ## Object Pools
+ */
+
+/**
+ * A pool of `Vector objects that are used in calculations to avoid allocating memory.
+ * 
+ * @type {Array<Vector>}
+ */
+const T_VECTORS = [];
+for (let i = 0; i < 10; i++) T_VECTORS.push(new Vector());
+
+/**
+ * A pool of arrays of numbers used in calculations to avoid allocating memory.
+ * 
+ * @type {Array<Array<number>>}
+ */
+const T_ARRAYS = [];
+for (let i = 0; i < 5; i++) T_ARRAYS.push([]);
+
+/**
+ * Temporary response used for Polygon hit detection.
+ * 
+ * @type {Response}
+ */
+const T_RESPONSE = new Response();
+
+/**
+ * Tiny "point" Polygon used for Polygon hit detection.
+ * 
+ * @type {Polygon}
+ */
+const TEST_POINT = new Box(new Vector(), 0.000001, 0.000001).toPolygon();
+
+/**
+ * ## Constants for Voronoi regions.
+ */
+const LEFT_VORONOI_REGION = -1;
+const MIDDLE_VORONOI_REGION = 0;
+const RIGHT_VORONOI_REGION = 1;
+
+/**
+ * ## Helper Functions
+ */
+
+/**
+ * Flattens the specified array of points onto a unit vector axis resulting in a one dimensionsl
+ * range of the minimum and maximum value on that axis.
+ * 
+ * @param {Array<Vector>} points The points to flatten.
+ * @param {Vector} normal The unit vector axis to flatten on.
+ * @param {Array<number>} result An array. After calling this function, result[0] will be the minimum value, result[1] will be the maximum value.
+ */
+function flattenPointsOn(points, normal, result) {
+  let min = Number.MAX_VALUE;
+  let max = -Number.MAX_VALUE;
+
+  const len = points.length;
+
+  for (let i = 0; i < len; i++) {
+    // The magnitude of the projection of the point onto the normal.
+    const dot = points[i].dot(normal);
+
+    if (dot < min) min = dot;
+    if (dot > max) max = dot;
+  }
+
+  result[0] = min;
+  result[1] = max;
+}
+
+/**
+ * Calculates which Voronoi region a point is on a line segment.
+ * 
+ * It is assumed that both the line and the point are relative to `(0,0)`
+ * 
+ *             |       (0)      |
+ *      (-1)  [S]--------------[E]  (1)
+ *            |       (0)      |
+ * 
+ * @param {Vector} line The line segment.
+ * @param {Vector} point The point.
+ * @return {number} LEFT_VORONOI_REGION (-1) if it is the left region,
+ *                  MIDDLE_VORONOI_REGION (0) if it is the middle region,
+ *                  RIGHT_VORONOI_REGION (1) if it is the right region.
+ */
+function voronoiRegion(line, point) {
+  const len2 = line.len2();
+  const dp = point.dot(line);
+
+  // If the point is beyond the start of the line, it is in the left voronoi region.
+  if (dp < 0) return LEFT_VORONOI_REGION;
+
+  // If the point is beyond the end of the line, it is in the right voronoi region.
+  else if (dp > len2) return RIGHT_VORONOI_REGION;
+
+  // Otherwise, it's in the middle one.
+  else return MIDDLE_VORONOI_REGION;
+}
+
+export default {
+  Box,
+  Vector,
+  Circle,
+  Polygon,
+  Response,
+  V: Vector,
+  
+  /**
+   * Check whether two convex polygons are separated by the specified axis (must be a unit vector).
+   * 
+   * @param {Vector} aPos The position of the first polygon.
+   * @param {Vector} bPos The position of the second polygon.
+   * @param {Array<Vector>} aPoints The points in the first polygon.
+   * @param {Array<Vector>} bPoints The points in the second polygon.
+   * @param {Vector} axis The axis (unit sized) to test against.  The points of both polygons will be projected onto this axis.
+   * @param {Response=} response A Response object (optional) which will be populated if the axis is not a separating axis.
+   * @return {boolean} true if it is a separating axis, false otherwise.  If false, and a response is passed in, information about how much overlap and the direction of the overlap will be populated.
+   */
+  isSeparatingAxis(aPos, bPos, aPoints, bPoints, axis, response) {
+    const rangeA = T_ARRAYS.pop();
+    const rangeB = T_ARRAYS.pop();
+  
+    // The magnitude of the offset between the two polygons
+    const offsetV = T_VECTORS.pop().copy(bPos).sub(aPos);
+    const projectedOffset = offsetV.dot(axis);
+  
+    // Project the polygons onto the axis.
+    flattenPointsOn(aPoints, axis, rangeA);
+    flattenPointsOn(bPoints, axis, rangeB);
+  
+    // Move B's range to its position relative to A.
+    rangeB[0] += projectedOffset;
+    rangeB[1] += projectedOffset;
+  
+    // Check if there is a gap. If there is, this is a separating axis and we can stop
+    if (rangeA[0] > rangeB[1] || rangeB[0] > rangeA[1]) {
+      T_VECTORS.push(offsetV);
+  
+      T_ARRAYS.push(rangeA);
+      T_ARRAYS.push(rangeB);
+  
+      return true;
+    }
+  
+    // This is not a separating axis. If we're calculating a response, calculate the overlap.
+    if (response) {
+      let overlap = 0;
+  
+      // A starts further left than B
+      if (rangeA[0] < rangeB[0]) {
+        response['aInB'] = false;
+  
+        // A ends before B does. We have to pull A out of B
+        if (rangeA[1] < rangeB[1]) {
+          overlap = rangeA[1] - rangeB[0];
+  
+          response['bInA'] = false;
+          // B is fully inside A.  Pick the shortest way out.
+        } else {
+          const option1 = rangeA[1] - rangeB[0];
+          const option2 = rangeB[1] - rangeA[0];
+  
+          overlap = option1 < option2 ? option1 : -option2;
+        }
+        // B starts further left than A
+      } else {
+        response['bInA'] = false;
+  
+        // B ends before A ends. We have to push A out of B
+        if (rangeA[1] > rangeB[1]) {
+          overlap = rangeA[0] - rangeB[1];
+  
+          response['aInB'] = false;
+          // A is fully inside B.  Pick the shortest way out.
+        } else {
+          const option1 = rangeA[1] - rangeB[0];
+          const option2 = rangeB[1] - rangeA[0];
+  
+          overlap = option1 < option2 ? option1 : -option2;
+        }
+      }
+  
+      // If this is the smallest amount of overlap we've seen so far, set it as the minimum overlap.
+      const absOverlap = Math.abs(overlap);
+  
+      if (absOverlap < response['overlap']) {
+        response['overlap'] = absOverlap;
+        response['overlapN'].copy(axis);
+  
+        if (overlap < 0) response['overlapN'].reverse();
+      }
+    }
+  
+    T_VECTORS.push(offsetV);
+  
+    T_ARRAYS.push(rangeA);
+    T_ARRAYS.push(rangeB);
+  
+    return false;
+  },
+
+  /**
+   * ## Collision Tests
+   */
+
+  /**
+   * Check if a point is inside a circle.
+   * 
+   * @param {Vector} p The point to test.
+   * @param {Circle} c The circle to test.
+   * 
+   * @returns {boolean} Returns true if the point is inside the circle or false otherwise.
+   */
+  pointInCircle(p, c) {
+    const differenceV = T_VECTORS.pop().copy(p).sub(c['pos']).sub(c['offset']);
+
+    const radiusSq = c['r'] * c['r'];
+    const distanceSq = differenceV.len2();
+
+    T_VECTORS.push(differenceV);
+
+    // If the distance between is smaller than the radius then the point is inside the circle.
+    return distanceSq <= radiusSq;
+  },
+
+  /**
+   * Check if a point is inside a convex polygon.
+   * 
+   * @param {Vector} p The point to test.
+   * @param {Polygon} poly The polygon to test.
+   * 
+   * @returns {boolean} Returns true if the point is inside the polygon or false otherwise.
+   */
+  pointInPolygon(p, poly) {
+    TEST_POINT['pos'].copy(p);
+    T_RESPONSE.clear();
+
+    let result = this.testPolygonPolygon(TEST_POINT, poly, T_RESPONSE);
+
+    if (result) result = T_RESPONSE['aInB'];
+
+    return result;
+  },
+
+  /**
+   * Check if two circles collide.
+   * 
+   * @param {Circle} a The first circle.
+   * @param {Circle} b The second circle.
+   * @param {Response} [response] An optional response object that will be populated if the circles intersect.
+   * 
+   * @returns {boolean} Returns true if the circles intersect or false otherwise.
+   */
+  testCircleCircle(a, b, response) {
+    // Check if the distance between the centers of the two circles is greater than their combined radius.
+    const differenceV = T_VECTORS.pop().copy(b['pos']).add(b['offset']).sub(a['pos']).sub(a['offset']);
+
+    const totalRadius = a['r'] + b['r'];
+    const totalRadiusSq = totalRadius * totalRadius;
+    const distanceSq = differenceV.len2();
+
+    // If the distance is bigger than the combined radius, they don't intersect.
+    if (distanceSq > totalRadiusSq) {
+      T_VECTORS.push(differenceV);
+
+      return false;
+    }
+
+    // They intersect.  If we're calculating a response, calculate the overlap.
+    if (response) {
+      const dist = Math.sqrt(distanceSq);
+
+      response.a = a;
+      response.b = b;
+
+      response.overlap = totalRadius - dist;
+      response.overlapN.copy(differenceV.normalize());
+      response.overlapV.copy(differenceV).scale(response.overlap);
+
+      response.aInB = a.r <= b.r && dist <= b.r - a.r;
+      response.bInA = b.r <= a.r && dist <= a.r - b.r;
+    }
+
+    T_VECTORS.push(differenceV);
+
+    return true;
+  },
+
+  /**
+   * Check if a polygon and a circle collide.
+   * 
+   * @param {Polygon} polygon The polygon.
+   * @param {Circle} circle The circle.
+   * @param {Response} [response] An optional response object that will be populated if they intersect.
+   * 
+   * @returns {boolean} Returns true if they intersect or false otherwise.
+   */
+  testPolygonCircle(polygon, circle, response) {
+    // Get the position of the circle relative to the polygon.
+    const circlePos = T_VECTORS.pop().copy(circle.pos).add(circle.offset).sub(polygon.pos);
+
+    const radius = circle.r;
+    const radius2 = radius * radius;
+
+    const points = polygon.calcPoints;
+    const len = points.length;
+
+    const edge = T_VECTORS.pop();
+    const point = T_VECTORS.pop();
+
+    // For each edge in the polygon:
+    for (var i = 0; i < len; i++) {
+      const next = i === len - 1 ? 0 : i + 1;
+      const prev = i === 0 ? len - 1 : i - 1;
+
+      let overlap = 0;
+      let overlapN = null;
+
+      // Get the edge.
+      edge.copy(polygon.edges[i]);
+
+      // Calculate the center of the circle relative to the starting point of the edge.
+      point.copy(circlePos).sub(points[i]);
+
+      // If the distance between the center of the circle and the point is bigger than the radius, the polygon is definitely not fully in the circle.
+      if (response && point.len2() > radius2) response.aInB = false;
+
+      // Calculate which Voronoi region the center of the circle is in.
+      let region = voronoiRegion(edge, point);
+
+      // If it's the left region:
+      if (region === LEFT_VORONOI_REGION) {
+        // We need to make sure we're in the RIGHT_VORONOI_REGION of the previous edge.
+        edge.copy(polygon.edges[prev]);
+
+        // Calculate the center of the circle relative the starting point of the previous edge
+        const point2 = T_VECTORS.pop().copy(circlePos).sub(points[prev]);
+
+        region = voronoiRegion(edge, point2);
+
+        if (region === RIGHT_VORONOI_REGION) {
+          // It's in the region we want.  Check if the circle intersects the point.
+          const dist = point.len();
+
+          if (dist > radius) {
+            // No intersection
+            T_VECTORS.push(circlePos);
+            T_VECTORS.push(edge);
+            T_VECTORS.push(point);
+            T_VECTORS.push(point2);
+
+            return false;
+          } else if (response) {
+            // It intersects, calculate the overlap.
+            response.bInA = false;
+
+            overlapN = point.normalize();
+            overlap = radius - dist;
+          }
+        }
+
+        T_VECTORS.push(point2);
+
+        // If it's the right region:
+      } else if (region === RIGHT_VORONOI_REGION) {
+        // We need to make sure we're in the left region on the next edge
+        edge.copy(polygon.edges[next]);
+
+        // Calculate the center of the circle relative to the starting point of the next edge.
+        point.copy(circlePos).sub(points[next]);
+
+        region = voronoiRegion(edge, point);
+
+        if (region === LEFT_VORONOI_REGION) {
+          // It's in the region we want.  Check if the circle intersects the point.
+          const dist = point.len();
+
+          if (dist > radius) {
+            // No intersection
+            T_VECTORS.push(circlePos);
+            T_VECTORS.push(edge);
+            T_VECTORS.push(point);
+
+            return false;
+          } else if (response) {
+            // It intersects, calculate the overlap.
+            response.bInA = false;
+
+            overlapN = point.normalize();
+            overlap = radius - dist;
+          }
+        }
+        // Otherwise, it's the middle region:
+      } else {
+        // Need to check if the circle is intersecting the edge, change the edge into its "edge normal".
+        const normal = edge.perp().normalize();
+
+        // Find the perpendicular distance between the center of the circle and the edge.
+        const dist = point.dot(normal);
+        const distAbs = Math.abs(dist);
+
+        // If the circle is on the outside of the edge, there is no intersection.
+        if (dist > 0 && distAbs > radius) {
+          // No intersection
+          T_VECTORS.push(circlePos);
+          T_VECTORS.push(normal);
+          T_VECTORS.push(point);
+
+          return false;
+        } else if (response) {
+          // It intersects, calculate the overlap.
+          overlapN = normal;
+          overlap = radius - dist;
+
+          // If the center of the circle is on the outside of the edge, or part of the circle is on the outside, the circle is not fully inside the polygon.
+          if (dist >= 0 || overlap < 2 * radius) response.bInA = false;
+        }
+      }
+
+      // If this is the smallest overlap we've seen, keep it.
+      // (overlapN may be null if the circle was in the wrong Voronoi region).
+      if (overlapN && response && Math.abs(overlap) < Math.abs(response.overlap)) {
+        response.overlap = overlap;
+        response.overlapN.copy(overlapN);
+      }
+    }
+
+    // Calculate the final overlap vector - based on the smallest overlap.
+    if (response) {
+      response.a = polygon;
+      response.b = circle;
+
+      response.overlapV.copy(response.overlapN).scale(response.overlap);
+    }
+
+    T_VECTORS.push(circlePos);
+    T_VECTORS.push(edge);
+    T_VECTORS.push(point);
+
+    return true;
+  },
+
+  /**
+   * Check if a circle and a polygon collide.
+   * 
+   * **NOTE:** This is slightly less efficient than polygonCircle as it just runs polygonCircle and reverses everything
+   * at the end.
+   * 
+   * @param {Circle} circle The circle.
+   * @param {Polygon} polygon The polygon.
+   * @param {Response} [response] An optional response object that will be populated if they intersect.
+   * 
+   * @returns {boolean} Returns true if they intersect or false otherwise.
+   */
+  testCirclePolygon(circle, polygon, response) {
+    // Test the polygon against the circle.
+    const result = testPolygonCircle(polygon, circle, response);
+
+    if (result && response) {
+      // Swap A and B in the response.
+      const a = response.a;
+      const aInB = response.aInB;
+
+      response.overlapN.reverse();
+      response.overlapV.reverse();
+
+      response.a = response.b;
+      response.b = a;
+
+      response.aInB = response.bInA;
+      response.bInA = aInB;
+    }
+
+    return result;
+  },
+
+  /**
+   * Checks whether polygons collide.
+   * 
+   * @param {Polygon} a The first polygon.
+   * @param {Polygon} b The second polygon.
+   * @param {Response} [response] An optional response object that will be populated if they intersect.
+   * 
+   * @returns {boolean} Returns true if they intersect or false otherwise.
+   */
+  testPolygonPolygon(a, b, response) {
+    const aPoints = a.calcPoints;
+    const aLen = aPoints.length;
+
+    const bPoints = b.calcPoints;
+    const bLen = bPoints.length;
+
+    // If any of the edge normals of A is a separating axis, no intersection.
+    for (let i = 0; i < aLen; i++) {
+      if (this.isSeparatingAxis(a.pos, b.pos, aPoints, bPoints, a.normals[i], response)) {
+        return false;
+      }
+    }
+
+    // If any of the edge normals of B is a separating axis, no intersection.
+    for (let i = 0; i < bLen; i++) {
+      if (this.isSeparatingAxis(a.pos, b.pos, aPoints, bPoints, b.normals[i], response)) {
+        return false;
+      }
+    }
+
+    // Since none of the edge normals of A or B are a separating axis, there is an intersection
+    // and we've already calculated the smallest overlap (in isSeparatingAxis). 
+    // Calculate the final overlap vector.
+    if (response) {
+      response['a'] = a;
+      response['b'] = b;
+
+      response['overlapV'].copy(response['overlapN']).scale(response['overlap']);
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
Sorry for the huge PR but this couldn't be an incremental change.

- Added src folder that contains the new individual classes for Box, Circle, Polygon, etc.
- Kept the same code but changed vars to lets/consts where applicable.
- Added @babel/core and @babel/present-env packages and .babelrc file so that the new ES6 code can transpiled to ES5.
- Added rollup.config.js file so that a umd build can be created with `npm run bundle` or `npm run bundle:watch`.
- Created new SAT.js file using Rollup and ran the tests to make sure they all still passed.