### PR TITLE
Return a Box from getAABB()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ It has the following properties:
  It has the following methods:
 
  - `setOffset(offset)` - Set the current offset
- - `getAABB()` - Compute the axis-aligned bounding box. Returns a new Box every time it is called.
+ - `getAABB()` - Compute the axis-aligned bounding box. Returns a new Polygon every time it is called.
+ - `getAABBAsBox()` - Compute the axis-aligned bounding box. Returns a new Box every time it is called.
 
 ### SAT.Polygon
 
@@ -114,7 +115,8 @@ It has the following methods:
  - `setOffset(offset)` - Set the current offset
  - `rotate(angle)` - Rotate the original points of this polygon counter-clockwise (around its local coordinate system) by the specified number of radians. The `angle` rotation will be applied on top of this rotation.
  - `translate(x, y)` - Translate the original points of this polygon (relative to the local coordinate system) by the specified amounts. The `offset` translation will be applied on top of this translation.
- - `getAABB()` - Compute the axis-aligned bounding box. Returns a new Box every time it is called. Is performed based on the `calcPoints`.
+ - `getAABB()` - Compute the axis-aligned bounding box. Returns a new Polygon every time it is called. Is performed based on the `calcPoints`.
+ - `getAABBAsBox()` - Compute the axis-aligned bounding box. Returns a new Box every time it is called. Is performed based on the `calcPoints`.
  - `getCentroid()` - Compute the [Centroid](https://en.wikipedia.org/wiki/Centroid#Centroid_of_a_polygon) of the polygon. Is performed based on the `calcPoints`.
 
 ### SAT.Box

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ It has the following properties:
  It has the following methods:
 
  - `setOffset(offset)` - Set the current offset
+ - `getAABB()` - Compute the axis-aligned bounding box. Returns a new Box every time it is called.
 
 ### SAT.Polygon
 
@@ -113,7 +114,7 @@ It has the following methods:
  - `setOffset(offset)` - Set the current offset
  - `rotate(angle)` - Rotate the original points of this polygon counter-clockwise (around its local coordinate system) by the specified number of radians. The `angle` rotation will be applied on top of this rotation.
  - `translate(x, y)` - Translate the original points of this polygon (relative to the local coordinate system) by the specified amounts. The `offset` translation will be applied on top of this translation.
- - `getAABB()` - Compute the axis-aligned bounding box. Returns a new Polygon every time it is called. Is performed based on the `calcPoints`.
+ - `getAABB()` - Compute the axis-aligned bounding box. Returns a new Box every time it is called. Is performed based on the `calcPoints`.
  - `getCentroid()` - Compute the [Centroid](https://en.wikipedia.org/wiki/Centroid#Centroid_of_a_polygon) of the polygon. Is performed based on the `calcPoints`.
 
 ### SAT.Box

--- a/SAT.js
+++ b/SAT.js
@@ -270,7 +270,7 @@
   Circle.prototype['getAABB'] = Circle.prototype.getAABB = function() {
     var r = this['r'];
     var corner = this['pos'].clone().add(this['offset']).sub(new Vector(r, r));
-    return new Box(corner, r*2, r*2).toPolygon();
+    return new Box(corner, r*2, r*2);
   };
 
   // Set the current offset to apply to the radius.
@@ -483,7 +483,7 @@
         yMax = point["y"];
       }
     }
-    return new Box(this['pos'].clone().add(new Vector(xMin, yMin)), xMax - xMin, yMax - yMin).toPolygon();
+    return new Box(this['pos'].clone().add(new Vector(xMin, yMin)), xMax - xMin, yMax - yMin);
   };
 
   // Compute the centroid (geometric center) of the polygon. Any current state

--- a/SAT.js
+++ b/SAT.js
@@ -263,14 +263,24 @@
 
   // Compute the axis-aligned bounding box (AABB) of this Circle.
   //
+  // Note: Returns a _new_ `Box` each time you call this.
+  /**
+   * @return {Polygon} The AABB
+   */
+  Circle.prototype['getAABBAsBox'] = Circle.prototype.getAABBAsBox = function() {
+    var r = this['r'];
+    var corner = this['pos'].clone().add(this['offset']).sub(new Vector(r, r));
+    return new Box(corner, r*2, r*2);
+  };
+
+  // Compute the axis-aligned bounding box (AABB) of this Circle.
+  //
   // Note: Returns a _new_ `Polygon` each time you call this.
   /**
    * @return {Polygon} The AABB
    */
   Circle.prototype['getAABB'] = Circle.prototype.getAABB = function() {
-    var r = this['r'];
-    var corner = this['pos'].clone().add(this['offset']).sub(new Vector(r, r));
-    return new Box(corner, r*2, r*2);
+    return this.getAABBAsBox().toPolygon();
   };
 
   // Set the current offset to apply to the radius.
@@ -457,11 +467,11 @@
   // Compute the axis-aligned bounding box. Any current state
   // (translations/rotations) will be applied before constructing the AABB.
   //
-  // Note: Returns a _new_ `Polygon` each time you call this.
+  // Note: Returns a _new_ `Box` each time you call this.
   /**
    * @return {Polygon} The AABB
    */
-  Polygon.prototype["getAABB"] = Polygon.prototype.getAABB = function() {
+  Polygon.prototype["getAABBAsBox"] = Polygon.prototype.getAABBAsBox = function() {
     var points = this["calcPoints"];
     var len = points.length;
     var xMin = points[0]["x"];
@@ -484,6 +494,18 @@
       }
     }
     return new Box(this['pos'].clone().add(new Vector(xMin, yMin)), xMax - xMin, yMax - yMin);
+  };
+
+
+  // Compute the axis-aligned bounding box. Any current state
+  // (translations/rotations) will be applied before constructing the AABB.
+  //
+  // Note: Returns a _new_ `Polygon` each time you call this.
+  /**
+   * @return {Polygon} The AABB
+   */
+  Polygon.prototype["getAABB"] = Polygon.prototype.getAABB = function() {
+    return this.getAABBAsBox().toPolygon();
   };
 
   // Compute the centroid (geometric center) of the polygon. Any current state


### PR DESCRIPTION
Here is my use-case: I need to obtain the bounding box of a `Polygon` or a `Circle` (to align the edges of the object's AABB with a grid).

When you have a `Box`, it's easy to get, let's say, the top-left vertex. But with a `Polygon`, it's tedious because you have to iterate over all the vertices.

Also, for people who really want the AABB, it's still easy to get it with `myCircle.getAABB().asPolygon()`.